### PR TITLE
Add command-line flags to pass URLs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: "1.20"
 
     - name: Build
       run: go build -v ./...

--- a/cmd/korrel8r/cmd/root.go
+++ b/cmd/korrel8r/cmd/root.go
@@ -37,6 +37,9 @@ var (
 	output     *string
 	verbose    *int
 	rulePaths  *[]string
+	metricsAPI *string
+	alertsAPI  *string
+	logsAPI    *string
 	panicOnErr *bool
 )
 
@@ -45,6 +48,9 @@ func init() {
 	output = rootCmd.PersistentFlags().StringP("output", "o", "yaml", "Output format: json, json-pretty or yaml")
 	verbose = rootCmd.PersistentFlags().IntP("verbose", "v", 0, "Verbosity for logging")
 	rulePaths = rootCmd.PersistentFlags().StringArray("rules", defaultRulePaths(), "Files or directories containing rules.")
+	metricsAPI = rootCmd.PersistentFlags().StringP("metrics-url", "", "", "URL to the metrics API")
+	alertsAPI = rootCmd.PersistentFlags().StringP("alerts-url", "", "", "URL to the alerts API")
+	logsAPI = rootCmd.PersistentFlags().StringP("logs-url", "", "", "URL to the logs API")
 	cobra.OnInitialize(func() { logging.Init(*verbose) })
 }
 
@@ -64,7 +70,7 @@ func Execute() (exitCode int) {
 // defaultRulePaths looks for a default "rules" directory in a few places.
 func defaultRulePaths() []string {
 	for _, f := range []func() string{
-		func() string { return os.Getenv("KORREL8R_RULE_DIR") },                                        // Environment directory
+		func() string { return os.Getenv("KORREL8R_RULE_DIR") },                                       // Environment directory
 		func() string { exe, _ := os.Executable(); return filepath.Join(filepath.Dir(exe), "rules") }, // Beside executable
 		func() string { // must.Must for source tree
 			_, path, _, _ := runtime.Caller(1)

--- a/pkg/domains/alert/openshift.go
+++ b/pkg/domains/alert/openshift.go
@@ -2,6 +2,7 @@ package alert
 
 import (
 	"context"
+	"net/url"
 
 	"github.com/korrel8r/korrel8r/pkg/korrel8r"
 	"github.com/korrel8r/korrel8r/pkg/openshift"
@@ -14,19 +15,27 @@ const (
 	AlertmanagerMain = "alertmanager-main"
 )
 
-// OpenshiftManagerStore creates a store client for the openshift alert manager.
+// OpenshiftManagerStore creates a store client for the in-cluster OpenShift Alertmanager's route.
 func NewOpenshiftAlertManagerStore(ctx context.Context, cfg *rest.Config) (korrel8r.Store, error) {
 	c, err := client.New(cfg, client.Options{})
 	if err != nil {
 		return nil, err
 	}
+
 	host, err := openshift.RouteHost(ctx, c, openshift.AlertmanagerMainNSName)
 	if err != nil {
 		return nil, err
 	}
+
 	hc, err := rest.HTTPClientFor(cfg)
 	if err != nil {
 		return nil, err
 	}
-	return NewStore(host, hc), nil
+
+	u := &url.URL{
+		Scheme: "https",
+		Host:   host,
+	}
+
+	return NewStore(u, hc)
 }

--- a/pkg/domains/metric/metric.go
+++ b/pkg/domains/metric/metric.go
@@ -76,7 +76,7 @@ func (q *Query) Class() korrel8r.Class { return Class{} }
 type Store struct{ api promv1.API }
 
 func NewStore(base *url.URL, hc *http.Client) (*Store, error) {
-	c, err := api.NewClient(api.Config{Address: base.String(), RoundTripper: hc.Transport})
+	c, err := api.NewClient(api.Config{Address: base.String(), Client: hc})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This change adds CLI options to provide URLs of the metrics, logs and alerts APIs instead of relying on the built-in OpenShift routes. This is a first step in decoupling korrel8r from OpenShift and making it platform-agnostic.

cc @alanconway 