### PR TITLE
Add PodToAlert and NamespaceToAlert rules

### DIFF
--- a/pkg/domains/k8s/k8s_test.go
+++ b/pkg/domains/k8s/k8s_test.go
@@ -29,9 +29,12 @@ func TestDomain_Class(t *testing.T) {
 		name string
 		want korrel8r.Class
 	}{
+		{"Namespace", ClassOf(&corev1.Namespace{})},           // Kind only
+		{"Namespace.", ClassOf(&corev1.Namespace{})},          // Kind and version
+		{"Namespace.v1.", ClassOf(&corev1.Namespace{})},       // Kind, version and group
 		{"Pod", ClassOf(&corev1.Pod{})},                       // Kind only
 		{"Pod.", ClassOf(&corev1.Pod{})},                      // Kind and group (core group is named "")
-		{"Pod.v1.", ClassOf(&corev1.Pod{})},                   // Kind, version gand roup.
+		{"Pod.v1.", ClassOf(&corev1.Pod{})},                   // Kind, version and group.
 		{"Deployment.apps", ClassOf(&appsv1.Deployment{})},    // Kind only
 		{"Deployment.apps", ClassOf(&appsv1.Deployment{})},    // Kind and group
 		{"Deployment.v1.apps", ClassOf(&appsv1.Deployment{})}, // Kind, version and group

--- a/rules/k8s.yaml
+++ b/rules/k8s.yaml
@@ -65,6 +65,22 @@ groups:
 #      - AppliedClusterResourceQuota
 #      - ClusterResourceQuota
 
+  - name: namespacedResources
+    classes:
+      - Pod
+      - Deployment.apps
+      - DeploymentConfig.apps.openshift.io
+      - StatefulSet.apps
+      - CronJob.batch
+      - Job.batch
+      - DaemonSet.apps
+      - ReplicaSet.apps
+      - ReplicationController
+      - PersistentVolumeClaim
+      - Service
+      - Route.route.openshift.io
+      - Ingress.networking.k8s.io
+
 rules:
    - name: SelectorToLogs
      start:
@@ -91,6 +107,49 @@ rules:
            "LogType": "{{ k8sLogType .Namespace }}",
            "LogQL": "{kubernetes_namespace_name=\"{{.Namespace}}\",kubernetes_pod_name=\"{{.Name}}\"} | json"
          }
+
+   - name: NamespacedResourceToNamespace
+     start:
+       domain: k8s
+       classes: [namespacedResources]
+     goal:
+       domain: k8s
+       classes: [Namespace]
+     result:
+       query: |-
+         { Version: v1, Kind: Namespace, Name: {{.Namespace}} }
+
+   - name: NamespaceToAlert
+     start:
+       domain: k8s
+       classes: [Namespace]
+     goal:
+       domain: alert
+     result:
+       query: |-
+         {
+           "Labels":
+           {
+             "namespace": "{{.Name}}"
+           }
+         }
+
+   - name: PodToAlert
+     start:
+       domain: k8s
+       classes: [Pod]
+     goal:
+       domain: alert
+     result:
+       query: |-
+         {
+           "Labels":
+           {
+             "namespace": "{{.Namespace}}",
+             "pod": "{{.Name}}"
+           }
+         }
+
    - name: SelectorToPods
      start:
        domain: k8s


### PR DESCRIPTION
`PodToAlert` returns alerts that match a specific pod and `NamespaceToAlert`  returns alerts for a given namespace.

This change also introduces a `NamespacedResourceToNamespace` rule that start from a namespaced objet to the containing namespace. Starting from a k8s object, it can be useful to return all alerts related to the namespace even if the alerts don't match the object.