### PR TITLE
Fix store URLs in the correlate web page

### DIFF
--- a/cmd/korrel8r/webui/correlate.html.go
+++ b/cmd/korrel8r/webui/correlate.html.go
@@ -1,5 +1,6 @@
-//-*-web-*-
+// -*-web-*-
 package webui
+
 const correlateHTML = `
 {{define "body"}}
   <h1>Correlation Graph</h1>
@@ -87,7 +88,7 @@ const correlateHTML = `
                       {{range $qc := .QueryCounts.Sort}}
                         <li>
                           <a href="{{queryToConsole $qc.Query}}" target="_blank">Console</a> /
-                          <a href="/stores/{{$node.Class}}?query={{json $qc.Query | urlquery}}" target="_blank">Data</a>
+                          <a href="/stores/{{$node.Class.Domain}}?query={{json $qc.Query | urlquery}}" target="_blank">Data</a>
                           ({{$qc.Count}})
                           <pre>{{$qc.Query | json}}</pre>
                         </li>
@@ -113,7 +114,7 @@ const correlateHTML = `
   {{range $qc := .Sort}}
     <li>
       <a href="{{queryToConsole $qc.Query}}" target="_blank">Console</a> /
-      <a href="/stores/{{$qc.Query.Class}}?query={{json $qc.Query | urlquery}}" target="_blank">Data</a>
+      <a href="/stores/{{$qc.Query.Class.Domain}}?query={{json $qc.Query | urlquery}}" target="_blank">Data</a>
       ({{$qc.Count}})
       <pre>{{$qc.Query | json}}</pre>
     </li>

--- a/cmd/korrel8r/webui/stores.go
+++ b/cmd/korrel8r/webui/stores.go
@@ -12,20 +12,26 @@ import (
 type storeHandler struct{ ui *WebUI }
 
 func (h *storeHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	params := req.URL.Query()
-	domain, err := h.ui.Engine.DomainErr(path.Base(req.URL.Path))
+	path := path.Base(req.URL.Path)
+	log.V(2).Info("store handler", "path", path, "query", req.URL.RawQuery)
+
+	domain, err := h.ui.Engine.DomainErr(path)
 	if httpError(w, err, http.StatusNotFound) {
 		return
 	}
+
 	store, err := h.ui.Engine.StoreErr(
 		domain.String())
 	if httpError(w, err, http.StatusNotFound) {
 		return
 	}
+
+	params := req.URL.Query()
 	query, err := domain.UnmarshalQuery([]byte(params.Get("query")))
 	if httpError(w, err, http.StatusNotFound) {
 		return
 	}
+
 	result := korrel8r.NewResult(query.Class())
 	err = store.Get(context.Background(), query, result)
 	data := map[string]any{


### PR DESCRIPTION
The segment after `/stores`/ is supposed to be the domain name while it was the class name. As such links to k8s classes were broken and returned 404.