### PR TITLE
Deploy upstream Kubernetes dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-hack/jsonnet/vendor/
+hack/kind/jsonnet/vendor/
+korrel8r

--- a/hack/kind/README.md
+++ b/hack/kind/README.md
@@ -29,6 +29,7 @@ The following services are accessible via ingress:
 * `http://alertmanager.127.0.0.1.nip.io:8000`
 * `http://grafana.127.0.0.1.nip.io:8000`
 * `http://loki.127.0.0.1.nip.io:8000`
+* `http://dashboard.127.0.0.1.nip.io:8000`
 
 ## Using with korrel8r
 

--- a/hack/kind/config/kustomization.yaml
+++ b/hack/kind/config/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: logging
 
 resources:
 - https://github.com/grafana/loki/operator/config/overlays/development?ref=v2.7.4&timeout=600s
-#- ../../../../grafana/loki/operator/config/overlays/development/
+#- ../../../../../grafana/loki/operator/config/overlays/development/
 
 configMapGenerator:
 - files:

--- a/hack/kind/generate.sh
+++ b/hack/kind/generate.sh
@@ -10,6 +10,8 @@ set -o pipefail
 rm -rf manifests
 mkdir -p manifests/setup
 
+(cd jsonnet && jb install)
+
 # Calling gojsontoyaml is optional, but we would like to generate yaml, not json
 jsonnet -J jsonnet/vendor -m manifests jsonnet/main.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
 

--- a/hack/kind/jsonnet/ingress.libsonnet
+++ b/hack/kind/jsonnet/ingress.libsonnet
@@ -48,4 +48,18 @@ local rule(host, service, port) = {
       ],
     },
   },
+
+  dashboard: {
+    apiVersion: 'networking.k8s.io/v1',
+    kind: 'Ingress',
+    metadata: {
+      name: 'dashboard',
+      namespace: 'kubernetes-dashboard',
+    },
+    spec: {
+      rules: [
+        rule('dashboard.127.0.0.1.nip.io', 'dashboard-kubernetes-dashboard', 8080),
+      ],
+    },
+  },
 }

--- a/hack/kind/manifests/ingress-dashboard.yaml
+++ b/hack/kind/manifests/ingress-dashboard.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dashboard
+  namespace: kubernetes-dashboard
+spec:
+  rules:
+  - host: dashboard.127.0.0.1.nip.io
+    http:
+      paths:
+      - backend:
+          service:
+            name: dashboard-kubernetes-dashboard
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix

--- a/hack/kind/setup.sh
+++ b/hack/kind/setup.sh
@@ -37,6 +37,18 @@ EOF
 	wait_ready
 }
 
+create_dashboard() {
+       helm repo add kubernetes-dashboard https://kubernetes.github.io/dashboard/
+       cat <<EOF | helm install dashboard kubernetes-dashboard/kubernetes-dashboard -f - -n kubernetes-dashboard --create-namespace
+protocolHttp: true
+service:
+  externalPort: 8080
+rbac:
+  clusterReadOnlyRole: true
+EOF
+	wait_ready
+}
+
 apply() {
 	kubectl apply --server-side --force-conflicts -f "${SCRIPT_DIR}/manifests/setup"
 	kubectl apply --server-side --force-conflicts -f "${SCRIPT_DIR}/manifests/"
@@ -47,6 +59,7 @@ case ${1:-"help"} in
 create)
 	create_kind
 	create_ingress
+	create_dashboard
 	;;
 
 apply)


### PR DESCRIPTION
Eventually korrel8r should be able to integrate other Kubernetes consoles than OCP.

I've looked at different dashboard solutions for Kubernetes and couldn't find anything better than the official upstream dashboards. While it is a bit limited, alternative solutions had their own flaws:
* not fully open-source (e.g. Lens).
* Electron applications hence desktop-only.
* didn't provide more features (e.g. Headlamp).