### PR TITLE
feat: add deploy script to install the required operators and resources on OpenShift

### DIFF
--- a/hack/openshift/Makefile
+++ b/hack/openshift/Makefile
@@ -1,53 +1,9 @@
-NAMESPACES= -f manifests/0namespaces.yaml
-WATCH=oc get events -A --watch-only& trap "kill %%" EXIT;
+# This will deploy required Operators and resources that are required for Korrel8r
+.PHONY: deploy
+deploy:
+	./deploy.sh
 
-all: operators logging
-
-logging:
-	STORAGE_CLASS=$(STORAGE_CLASS) envsubst < manifests/lokistack.yaml.env > manifests/lokistack.yaml
-	oc apply -f ./manifests/
-	$(WATCH) until oc get -n openshift-logging $(LOGGGING_DEPLOYMENTS) $(LOGGING_STATEFULSETS); do echo waiting...; sleep 3;  done
-	$(WATCH) oc wait -n openshift-logging --for=condition=available $(LOGGING_DEPLOYMENTS)
-	$(WATCH) for S in $(LOGGING_STATEFULSETS); do echo $$S; oc rollout status  -n openshift-logging --watch $$S; done
-
-DEFAULT_SC=$(shell kubectl get storageclass -o=jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}')
-STORAGE_CLASS?=$(or $(DEFAULT_SC),$(error No default storage class, set STORAGE_CLASS))
-
-operators:
-	oc apply -f ./manifests/0namespaces.yaml
-	oc apply -f manifests/operators/
-	$(WATCH) for NAME in $(LOGGING_CSVS); do ../wait-for-csv.sh openshift-logging $$NAME; done
-
-namespaces:
-	oc apply $(NAMESPACES)
-
-delete:
-	oc delete --ignore-not-found $(LOGGING_MANIFESTS) --now || true
-
-LOGGING_DEPLOYMENTS=					\
-	deployment.apps/cluster-logging-operator	\
-	deployment.apps/logging-loki-distributor	\
-	deployment.apps/logging-loki-gateway		\
-	deployment.apps/logging-loki-querier		\
-	deployment.apps/logging-loki-query-frontend	\
-	deployment.apps/logging-view-plugin		\
-	deployment.apps/minio
-
-LOGGING_STATEFULSETS=					\
-	statefulset.apps/logging-loki-compactor		\
-	statefulset.apps/logging-loki-index-gateway	\
-	statefulset.apps/logging-loki-ingester
-
-LOGGING_CSVS=								\
-	clusterserviceversion.operators.coreos.com/cluster-logging	\
-	clusterserviceversion.operators.coreos.com/loki-operator
-
-delete-all: delete # Delete resources and operators, see fix-finalizer
-	oc delete --ignore-not-found subscription,replicaset,deployment,service -n openshift-operators-redhat -l app.kubernetes.io/part-of=cluster-logging
-	oc delete --ignore-not-found $(NAMESPACES)
-	oc delete --ignore-not-found operator/cluster-logging.openshift-logging operator/loki-operator.kubernetes-operators
-	oc delete --ignore-not-found -A crd,clusterrole -l app.kubernetes.io/part-of=cluster-logging
-
-fix-finalizer: # Work-around if ClusterLogging finalizer gets stuck and stops ns/openshift-logging from deleting.
-	oc patch --type json --patch='[ { "op": "remove", "path": "/metadata/finalizers" } ]' -n openshift-logging cl/instance || true
-	oc patch --type json --patch='[ { "op": "remove", "path": "/spec/finalizers" } ]' -n openshift-logging cl/instance || true
+# This will remove all the Operators and resources that were deployed
+.PHONY: undeploy
+undeploy:
+	./deploy.sh --delete

--- a/hack/openshift/README.md
+++ b/hack/openshift/README.md
@@ -6,10 +6,10 @@ This is not intended for production clusters.
 ## Create your cluster
 
 To get a personal test-cluster on your own machine,
-[install Openshift Local](https://developers.redhat.com/products/openshift-local/overview)
+[install OpenShift Local](https://developers.redhat.com/products/openshift-local/overview)
 (formerly known as Code Ready Containers or CRC)
 
-**NOTE**: These instructions will also work for other types of  Openshift cluster, provided you
+**NOTE**: These instructions will also work for other types of OpenShift cluster, provided you
 edit `manifests/lokistack.yaml` and set `storageClassName` to a storage class available on your cluster.
 To see available storage classes:
 
@@ -17,39 +17,39 @@ To see available storage classes:
 oc get storageclass
 ```
 
-## Installing Logging
-
-### Install operators
-
-    make operators
+## Installing Operators and Logging resources
 
 **Note**: You can also install the operators manually from OperatorHub:
-- "Red Hat Openshift Logging"
-- "Loki operator"
 
-### Create logging resources
+1. Red Hat OpenShift Logging
+1. Loki operators
 
-    make logging
+```bash
+make deploy
+```
 
 This will create resources in the `openshift-logging` namespace:
 
-1.  An extra-small LokiStack deployment for log storage and query.
-1.  A CluserLogging instance using vector to forward to LokiStack.
-1.  A ClusterLogForwarder instance to forward all logs (including audit logs)
+1. Deploy Red Hat OpenShift Logging and Loki Operators
+1. An extra-small LokiStack deployment for log storage and query.
+1. A CluserLogging instance using vector to forward to Loki Stack.
+1. A ClusterLogForwarder instance to forward all logs (including audit logs)
 
 ### View logs
 
-From the Openshift console: Observe > Logs
+From the OpenShift console: Observe > Logs
 
 ## Metrics, Alerts
 
-Installed with openshift.
-- Openshift console: Observe
+Installed with OpenShift.
+
+- OpenShift console: Observe
 
 ## Events
 
 Built in to k8s.
-- Openshift console: Home > Events
+
+- OpenShift console: Home > Events
 - Command line: `oc get events`
 
 

--- a/hack/openshift/deploy.sh
+++ b/hack/openshift/deploy.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+# constants
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+declare -r PROJECT_ROOT
+declare -r MANIFESTS_DIR="$PROJECT_ROOT/hack/openshift/manifests"
+declare -r LOGGING_DEPLOYMENTS=(
+	cluster-logging-operator
+	logging-loki-distributor
+	logging-loki-gateway
+	logging-loki-querier
+	logging-loki-query-frontend
+	logging-view-plugin
+	minio
+)
+declare -r LOGGING_STATEFULSETS=(
+	logging-loki-compactor
+	logging-loki-index-gateway
+	logging-loki-ingester
+)
+declare -r LOGGING_CSVS=(
+	cluster-logging
+	loki-operator
+)
+declare -r LOGGING_NS="openshift-logging"
+declare -r LOKI_NS="openshift-operators-redhat"
+declare -r CLUSTER_LOGGING="instance"
+declare -r LOKI_STACK="lokistack-loki"
+declare LOGS_DIR="$PROJECT_ROOT/tmp/deploy"
+# declare -r LOCAL_BIN="$PROJECT_ROOT/tmp/bin"
+declare -r LOKI_OPERATOR_DEPLOY_NAME="loki-operator-controller-manager"
+declare -r CLUSTER_LOGGING_OPERATOR_DEPLOY_NAME="cluster-logging-operator"
+declare SHOW_HELP=false
+declare DELETE_RESOURCE=false
+# config
+declare STORAGE_CLASS=${STORAGE_CLASS:-""}
+
+init_storage_class() {
+	echo "getting storage class from cluster"
+	STORAGE_CLASS=$(oc get storageclass -o=jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}')
+}
+
+init_logs_dir() {
+	rm -rf "$LOGS_DIR-prev"
+	mv "$LOGS_DIR" "$LOGS_DIR-prev" || true
+	mkdir -p "$LOGS_DIR"
+}
+
+parse_args() {
+	### while there are args parse them
+	while [[ -n "${1+xxx}" ]]; do
+		case $1 in
+		--help | -h)
+			shift
+			SHOW_HELP=true
+			return 0
+			;;
+		--delete)
+			DELETE_RESOURCE=true
+			return 0
+			;; # exit the loop
+		*)
+			return 1
+			;; # show usage on everything else
+		esac
+	done
+	return 0
+}
+print_usage() {
+	local scr
+	scr="$(basename "$0")"
+
+	read -r -d '' help <<-EOF_HELP || true
+		Usage:
+		  $scr
+		  $scr  --delete
+		 ─────────────────────────────────────────────────────────────────
+
+		Options:
+		  --delete                deletes all the resources
+	EOF_HELP
+
+	echo -e "$help"
+	return 0
+}
+
+must_gather() {
+	log_events "$LOGGING_NS"
+	log_events "$LOKI_NS"
+	watch_operator_errors
+}
+
+log_events() {
+	local ns="$1"
+	shift
+	oc get events \
+		-o custom-columns=FirstSeen:.firstTimestamp,LastSeen:.lastTimestamp,Count:.count,From:.source.component,Type:.type,Reason:.reason,Message:.message \
+		-n "$ns" | tee "$LOGS_DIR/$ns-events.log"
+}
+
+watch_operator_errors() {
+	oc logs -n "$LOGGING_NS" "deploy/$CLUSTER_LOGGING_OPERATOR_DEPLOY_NAME" | grep -i error | tee "$LOGS_DIR/cluster-logging-operator.log"
+	oc logs -n "$LOKI_NS" "deploy/$LOKI_OPERATOR_DEPLOY_NAME" | grep -i error | tee "$LOGS_DIR/loki-operator.log"
+}
+
+deploy_operators() {
+	echo "installing Red Hat OpenShift Logging & Loki Operator"
+
+	echo "creating required namespace for operators to install"
+	oc apply -f "$MANIFESTS_DIR/0namespaces.yaml" || {
+		echo "failed to configure the required namespace"
+		return 1
+	}
+
+	oc apply -f "$MANIFESTS_DIR/operators/" || {
+		echo "failed to configure operators"
+		return 1
+	}
+	for val in "${LOGGING_CSVS[@]}"; do
+		echo "waiting for $val to be created"
+		until csv=$(oc get -n "$LOGGING_NS" csv -o name | grep "$val"); do
+			echo "sleeping for 5s"
+			sleep 5
+		done
+		echo "waiting for $val to be succeeded"
+		oc wait --for=jsonpath='{.status.phase}'=Succeeded -n "$LOGGING_NS" "$csv" --timeout=5m || {
+			echo "$csv status is invalid"
+			return 1
+		}
+	done
+
+	echo "enabling logging console plugin"
+	oc patch consoles.operator.openshift.io cluster --type=merge \
+		--patch '{ "spec": { "plugins": ["logging-view-plugin"]}}' || {
+		echo "failed to patch the cluster for enabling logging console"
+		return 1
+	}
+	return 0
+}
+
+deploy_logging() {
+	echo "deploying lokistack"
+	oc process -p STORAGE_CLASS="$STORAGE_CLASS" -f "$MANIFESTS_DIR/lokistack.yaml" | oc apply -f - || {
+		echo "failed to deploy lokistack"
+		return 1
+	}
+	echo "deploying cluster logging"
+	oc apply -f "$MANIFESTS_DIR/clusterlogging.yaml" || {
+		echo "failed to deploy cluster logging"
+		return 1
+	}
+	oc patch clusterlogging "$CLUSTER_LOGGING" --type=merge \
+		--patch "{\"metadata\": {\"annotations\": {\"logging.openshift.io/ocp-console-migration-target\": \"$LOKI_STACK\"}}}" \
+		-n "$LOGGING_NS" || {
+		echo "failed to add annotation to clusterlogging CR"
+		return 1
+	}
+
+	echo "deploying cluster log forwarder"
+	oc apply -f "$MANIFESTS_DIR/clusterlogforwarder.yaml" || {
+		echo "failed to deploy cluster log forwarder"
+		return 1
+	}
+	return 0
+}
+
+validate() {
+	echo "checking status"
+	for deployment in "${LOGGING_DEPLOYMENTS[@]}"; do
+		echo "checking status of $deployment deployment"
+		oc rollout status -n "$LOGGING_NS" deployment "$deployment" --timeout=5m --watch || {
+			echo "invalid status for $deployment"
+			return 1
+		}
+	done
+	for statefulset in "${LOGGING_STATEFULSETS[@]}"; do
+		echo "checking status of $statefulset statefulset"
+		oc rollout status -n "$LOGGING_NS" statefulset "$statefulset" --timeout=5m --watch || {
+			echo "invalid status for $statefulset"
+			return 1
+		}
+	done
+	echo "all deployments and statefulsets are healthy"
+	return 0
+}
+
+deploy_minio() {
+	echo "deploying minio for lokistack"
+	oc apply -f "$MANIFESTS_DIR/minio.yaml" || {
+		echo "failed to deploy minio"
+		return 1
+	}
+	return 0
+}
+
+deploy_app() {
+	echo "deploying a dummy application for testing"
+	oc apply -f "$MANIFESTS_DIR/chat.yaml" || return 1
+	return 0
+}
+
+cleanup() {
+	local label="app.kubernetes.io/part-of=cluster-logging"
+	echo "cleaning up"
+	oc delete clusterloggings -A --all || true
+	oc delete clusterlogforwarder -A --all || true
+	oc delete lokistack -A --all || true
+	oc delete -f "$MANIFESTS_DIR/minio.yaml" || true
+	oc delete -f "$MANIFESTS_DIR/chat.yaml" || true
+	oc delete crd,clusterrole,clusterrolebinding -l "$label" -A || true
+	oc delete operators cluster-logging.openshift-logging || true
+	oc delete operators loki-operator.openshift-operators-redhat || true
+	oc delete -f "$MANIFESTS_DIR/0namespaces.yaml" || true
+
+	echo "resources and operators has been successfully uninstalled"
+}
+
+main() {
+	parse_args "$@" || {
+		print_usage
+		echo "failed to parse args"
+		return 1
+	}
+	$SHOW_HELP && {
+		print_usage
+		return 0
+	}
+	$DELETE_RESOURCE && {
+		cleanup
+		return 0
+	}
+	init_logs_dir
+	init_storage_class
+	deploy_operators || {
+		echo "operators deployment failed"
+		must_gather
+		return 1
+	}
+	deploy_minio || {
+		echo "minio deployment failed"
+		must_gather
+		return 1
+	}
+
+	deploy_logging || {
+		echo "logging resources deployment failed"
+		must_gather
+		return 1
+	}
+	deploy_app || {
+		echo "test app deployment failed"
+		must_gather
+		return 1
+	}
+	validate || {
+		echo "resources deployment validation failed. check for above errors"
+		must_gather
+		return 1
+	}
+
+}
+main "$@"

--- a/hack/openshift/manifests/lokistack.yaml
+++ b/hack/openshift/manifests/lokistack.yaml
@@ -1,19 +1,28 @@
 # Deploy lokistack into the openshift-logging namespace.
 ---
-apiVersion: loki.grafana.com/v1
-kind: LokiStack
+apiVersion: template.openshift.io/v1
+kind: Template
 metadata:
-  name: logging-loki
-  namespace: openshift-logging
-spec:
-  size: 1x.demo
-  storage:
-    schemas:
-    - version: v12
-      effectiveDate: 2022-06-01
-    secret:
-      name: minio
-      type: s3
-  storageClassName: local-storage
-  tenants:
-    mode: openshift-logging
+  name: lokistack-template
+objects:
+- apiVersion: loki.grafana.com/v1
+  kind: LokiStack
+  metadata:
+    name: logging-loki
+    namespace: ${NAMESPACE}
+  spec:
+    size: 1x.demo
+    storage:
+      schemas:
+      - version: v12
+        effectiveDate: 2022-06-01
+      secret:
+        name: minio
+        type: s3
+    storageClassName: ${STORAGE_CLASS}
+    tenants:
+      mode: openshift-logging
+parameters:
+  - name: STORAGE_CLASS
+  - name: NAMESPACE
+    value: openshift-logging


### PR DESCRIPTION
This PR adds `deploy.sh` inside `hack/openshift`. The script makes it easy to debug and maintain the required steps for Korrel8r to work. 
This doesn't change the way initially implemented steps were present in Makefile