### PR TITLE
fix: update image build target to include name of the Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ IMAGE=$(KORREL8R_IMAGE)
 
 ## OVERLAY: Name of kustomize directory for `make deploy`.
 OVERLAY?=config/overlays/dev
+## IMGTOOL: May be podman or docker.
+IMGTOOL?=$(or $(shell podman info > /dev/null 2>&1 && which podman), $(shell docker info > /dev/null 2>&1 && which docker))
 
 check: generate lint test ## Lint and test code.
 
@@ -75,7 +77,7 @@ run: $(GENERATED) ## Run `korrel8r web` using configuration in ./etc/korrel8r
 	go run ./cmd/korrel8r web -c $(CONFIG) $(ARGS)
 
 image-build: $(VERSION_TXT) ## Build image locally, don't push.
-	$(IMGTOOL) build --tag=$(IMAGE) .
+	$(IMGTOOL) build --tag=$(IMAGE) -f Containerfile .
 
 image: image-build ## Build and push image. IMG must be set to a writable image repository.
 	$(IMGTOOL) push -q $(IMAGE)


### PR DESCRIPTION
This PR updates the image-build target to include the name of the Dockerfile. Addresses #95 