### PR TITLE
feat: add shellcheck make target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,9 @@ jobs:
           key: cache-${{ runner.os }}-${{ runner.arch }}
 
       - name: Generate and Lint
-        run: make generate lint
+        run: |
+          make generate lint
+          git diff --exit-code
 
       - name: Test
         run: make test-skip

--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+GOOS="$(go env GOOS)"
+GOARCH="$(go env GOARCH)"
+
+# constants
+declare -r PROJECT_ROOT
+declare -r LOCAL_BIN="$PROJECT_ROOT/tmp/bin"
+
+# versions
+declare -r SHELLCHECK_VERSION=${SHELLCHECK_VERSION:-0.10.0}
+
+# install
+declare -r SHELLCHECK_URL="https://github.com/koalaman/shellcheck/releases/download/v$SHELLCHECK_VERSION/shellcheck-v$SHELLCHECK_VERSION"
+
+install_shellcheck() {
+	echo "installing shellcheck version: $SHELLCHECK_VERSION"
+
+	local arch="$GOARCH"
+	[[ $arch == "amd64" ]] && arch="x86_64"
+	[[ $arch == "arm64" ]] && arch="aarch64"
+
+	local install="$SHELLCHECK_URL.$GOOS.$arch.tar.xz"
+
+	wget -qO- "$install" | tar -xJf - -C "$LOCAL_BIN"
+	mv "$LOCAL_BIN/shellcheck-v$SHELLCHECK_VERSION/shellcheck" "$LOCAL_BIN"
+	rm -rf "$LOCAL_BIN/shellcheck-v$SHELLCHECK_VERSION"
+
+	echo "shellcheck installed to $LOCAL_BIN/shellcheck"
+}
+
+main() {
+	mkdir -p "$LOCAL_BIN"
+	export PATH="$LOCAL_BIN:$PATH"
+
+	install_shellcheck
+}
+main "$@"

--- a/hack/wait.sh
+++ b/hack/wait.sh
@@ -31,7 +31,7 @@ subscription() {
 		shift
 	fi
 	for NAME in "$@"; do
-		until CSV=$(oc get $NS_FLAG subscription/"$NAME" -o jsonpath='{.status.currentCSV}') && [ -n "$CSV" ]; do
+		until CSV=$(oc get "$NS_FLAG" subscription/"$NAME" -o jsonpath='{.status.currentCSV}') && [ -n "$CSV" ]; do
 			echo "waiting for CSV for subscription/$NAME $NS_FLAG"
 			sleep "$RETRY_DELAY"
 		done
@@ -40,7 +40,7 @@ subscription() {
 			sleep "$RETRY_DELAY"
 		done
 		echo "waiting for $CSV to have phase Succeeded"
-		oc wait --allow-missing-template-keys=true --for=jsonpath='{.status.phase}'=Succeeded $NS_FLAG csv/"$CSV" || return 1
+		oc wait --allow-missing-template-keys=true --for=jsonpath='{.status.phase}'=Succeeded "$NS_FLAG" csv/"$CSV" || return 1
 	done
 }
 


### PR DESCRIPTION
This PR adds `shellcheck` target which installs shellcheck tool locally. `make lint` will also run shellcheck