### PR TITLE
fix: update manifests for OpenShift

### DIFF
--- a/hack/openshift/Makefile
+++ b/hack/openshift/Makefile
@@ -13,23 +13,26 @@ STORAGE_CLASS?=$(shell kubectl get storageclass -o=jsonpath='{.items[?(@.metadat
 
 MINIO_ROLLOUT=../wait.sh rollout -n minio deployment/minio
 
-LOGGING_ROLLOUT=../wait.sh rollout -n openshift-logging	\
-deployment.apps/cluster-logging-operator		\
-deployment.apps/logging-loki-distributor		\
-deployment.apps/logging-loki-gateway			\
-deployment.apps/logging-loki-querier			\
-deployment.apps/logging-loki-query-frontend		\
+LOGGING_ROLLOUT=../wait.sh rollout -n openshift-logging \
+deployment.apps/cluster-logging-operator \
+deployment.apps/logging-loki-distributor \
+deployment.apps/logging-loki-gateway \
+deployment.apps/logging-loki-querier \
+deployment.apps/logging-loki-query-frontend \
 deployment.apps/logging-view-plugin
 
 
-NETOBSERV_ROLLOUT=../wait.sh rollout -n netobserv	\
-deployment.apps/loki-distributor			\
-deployment.apps/loki-gateway				\
-deployment.apps/loki-querier				\
-deployment.apps/loki-query-frontend			\
+NETOBSERV_ROLLOUT=../wait.sh rollout -n netobserv \
+deployment.apps/loki-distributor \
+deployment.apps/loki-gateway \
+deployment.apps/loki-querier \
+deployment.apps/loki-query-frontend \
 deployment.apps/netobserv-plugin
 
 resources:
+ifeq ($(strip $(STORAGE_CLASS)),)
+		$(error cannot determine storage class of cluster. exitting)
+endif
 	echo "STORAGE_CLASS=$(STORAGE_CLASS)" > config/resources/storage.env
 	kubectl apply -k config/resources
 	$(MINIO_ROLLOUT)
@@ -38,6 +41,6 @@ resources:
 
 clean-operators:
 	kubectl delete --ignore-not-found -k config/operators
-clean-resources:g
+clean-resources:
 	kubectl delete --ignore-not-found -k config/resources
 clean-all: clean-resources clean-operators

--- a/hack/openshift/config/resources/netobserv/kustomization.yaml
+++ b/hack/openshift/config/resources/netobserv/kustomization.yaml
@@ -1,4 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 namespace: netobserv
+
 resources:
+  - namespace.yaml
   - lokistack.yaml
   - flow_collector.yaml

--- a/hack/openshift/config/resources/netobserv/namespace.yaml
+++ b/hack/openshift/config/resources/netobserv/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: netobserv

--- a/hack/wait.sh
+++ b/hack/wait.sh
@@ -4,7 +4,7 @@
 set -e -o pipefail
 
 RETRY_LIMIT=${RETRY_LIMIT:-6}
-RETRY_DELAY=${RETRY_DELAY:-5s}
+RETRY_DELAY=${RETRY_DELAY:-5}
 TIMEOUT=5m
 
 retry() {


### PR DESCRIPTION
This change updates following:
* Makefile to include check in case of undefined storageclass. also fixes some indentation issues.
* removes `s` from `RETRY_DELAY` used inside `wait.sh` as sleep for macos doesn't support `<time>s`.
* fixes issue where make resource fails due to `netobserv` namespace not available before creating the `netobserv` resource.
```
echo "STORAGE_CLASS=managed-csi" > config/resources/storage.env
kubectl apply -k config/resources
namespace/chat created
namespace/minio created
configmap/storage-env-468h4442kd created
secret/minio created
secret/minio created
service/minio created
persistentvolumeclaim/minio created
deployment.apps/minio created
flowcollector.flows.netobserv.io/cluster created
clusterlogforwarder.logging.openshift.io/instance created
clusterlogging.logging.openshift.io/instance created
lokistack.loki.grafana.com/loki created
lokistack.loki.grafana.com/logging-loki created
pod/chat-x created
Error from server (NotFound): error when creating "config/resources": namespaces "netobserv" not found
make: *** [resources] Error 1
```