### PR TITLE
Lower mininum go version req to minor releases only

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/korrel8r/korrel8r
 
-go 1.21.5
+go 1.21
 
 // Bogus version that gets incorrectly required if not excluded.
 exclude k8s.io/client-go v12.0.0+incompatible


### PR DESCRIPTION
The following PR lessens the minor Go version requirement in `go.mod` to consider only minor releases and not specific patch releases. This allows specialized tooling as mod mirrors to use their custom go patch version (e.g. staying a bit behind) and still be able to download and mirror all dep modules.