### PR TITLE
fix: update openshift related manifests

### DIFF
--- a/hack/openshift/Makefile
+++ b/hack/openshift/Makefile
@@ -41,6 +41,7 @@ endif
 
 clean-operators:
 	kubectl delete --ignore-not-found -k config/operators
+	kubectl patch consoles.operator.openshift.io/cluster --type=merge --patch '{ "spec": { "plugins": [] }}'
 clean-resources:
 	kubectl delete --ignore-not-found -k config/resources
 clean-all: clean-resources clean-operators


### PR DESCRIPTION
This PR resolves an issue with checking operator subscriptions. The command `wait_for_resource "$ns" get subscription/"$NAME" -o jsonpath='{.status.currentCSV}'` fails to return a non-zero exit code when no CSV was found