### PR TITLE
fix #73: Fix forwarding of bearer tokens for Loki-based stores.

### DIFF
--- a/pkg/domains/log/log.go
+++ b/pkg/domains/log/log.go
@@ -225,7 +225,7 @@ func (s *store) Get(ctx context.Context, query korrel8r.Query, constraint *korre
 	if err != nil {
 		return err
 	}
-	return s.Client.Get(q.Data(), constraint, func(e *loki.Entry) { result.Append(NewObject(e.Line)) })
+	return s.Client.Get(ctx, q.Data(), constraint, func(e *loki.Entry) { result.Append(NewObject(e.Line)) })
 }
 
 type stackStore struct{ store }
@@ -235,7 +235,7 @@ func (s *stackStore) Get(ctx context.Context, query korrel8r.Query, constraint *
 	if err != nil {
 		return err
 	}
-	return s.Client.GetStack(q.Data(), q.Class().Name(), constraint, func(e *loki.Entry) { result.Append(NewObject(e.Line)) })
+	return s.Client.GetStack(ctx, q.Data(), q.Class().Name(), constraint, func(e *loki.Entry) { result.Append(NewObject(e.Line)) })
 }
 
 var logTypeRe = regexp.MustCompile(`{[^}]*log_type(=~*)"([^"]+)"}`)

--- a/pkg/domains/netflow/netflow.go
+++ b/pkg/domains/netflow/netflow.go
@@ -200,7 +200,7 @@ func (s *store) Get(ctx context.Context, query korrel8r.Query, c *korrel8r.Const
 	if err != nil {
 		return err
 	}
-	return s.Client.Get(q.logQL, c, func(e *loki.Entry) { result.Append(NewObject(e)) })
+	return s.Client.Get(ctx, q.logQL, c, func(e *loki.Entry) { result.Append(NewObject(e)) })
 }
 
 type stackStore struct{ store }
@@ -212,5 +212,5 @@ func (s *stackStore) Get(ctx context.Context, query korrel8r.Query, c *korrel8r.
 		return err
 	}
 
-	return s.Client.GetStack(q.logQL, "network", c, func(e *loki.Entry) { result.Append(NewObject(e)) })
+	return s.Client.GetStack(ctx, q.logQL, "network", c, func(e *loki.Entry) { result.Append(NewObject(e)) })
 }

--- a/pkg/rest/operations.go
+++ b/pkg/rest/operations.go
@@ -212,7 +212,7 @@ func (a *API) GetObjects(c *gin.Context) {
 	if !check(c, http.StatusInternalServerError, a.Engine.Get(auth.Context(c.Request), query, (*korrel8r.Constraint)(opts.Constraint), result)) {
 		return
 	}
-	log.V(2).Info("response OK", "objects", logging.JSON(result.List))
+	log.V(2).Info("response OK", "objects", len(result.List()))
 	c.JSON(http.StatusOK, result.List())
 }
 


### PR DESCRIPTION
Fixed: Loki-based stores were not using the context passed to Store.Get() so were not forwarding bearer tokens.