### PR TITLE
feat: better logging of rule and query evaluation.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,20 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
-        with:
-          go-version: "1.22"
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/go
-            ~/.cache/golangci-lint
-          key: cache-${{ runner.os }}-${{ runner.arch }}
 
-      - name: Lint
-        run: |
-          make GOLANGCI_LINT_CACHE=~/.cache/golangci-lint lint
-          git diff --exit-code
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.5'
 
-      - name: Test
+      - name: lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: 'v1.59.1'
+          args: "--timeout=3m"
+
+      - name: test
         run: make test-skip

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ $(SHELLCHECK):  $(BIN)
 
 lint: $(GEN_SRC) $(GOLANGCI_LINT) $(SHFMT) $(SHELLCHECK) ## Run the linter to find and fix code style problems.
 	hack/copyright.sh
-	$(GOLANGCI_LINT) run --fix --timeout 2m
+	$(GOLANGCI_LINT) run --fix
 	$(SHFMT) -l -w ./**/*.sh
 	$(SHELLCHECK) -x -S style hack/*.sh
 
@@ -87,7 +87,7 @@ $(GOCOVERDIR):
 	@mkdir -p $@
 
 run: $(KORREL8R) ## Run `korrel8r web` for debugging.
-	$(KORREL8R) web -c $(CONFIG) -v 2
+	$(KORREL8R) web -c $(CONFIG)
 
 image-build:  $(GEN_SRC) ## Build image locally, don't push.
 	$(IMGTOOL) build --tag=$(IMAGE) -f Containerfile .

--- a/cmd/korrel8r/web.go
+++ b/cmd/korrel8r/web.go
@@ -63,7 +63,8 @@ var webCmd = &cobra.Command{
 		gin.DisableConsoleColor()
 		router := gin.New()
 		router.Use(gin.Recovery())
-		r := must.Must1(rest.New(engine, configs, router))
+		r, err := rest.New(engine, configs, router)
+		must.Must(err)
 		defer r.Close()
 		s.Handler = router
 		pprof.Register(router) // Enable profiling

--- a/etc/korrel8r/rules/netflow.yaml
+++ b/etc/korrel8r/rules/netflow.yaml
@@ -42,7 +42,7 @@ rules:
       classes: [ netflowResource ]
     result:
       query: |-
-        k8s:{{.SrcK8S_Type}}:{namespace: "{{.SrcK8S_Namespace}}", name: "{{.SrcK8S_Name}}"}
+        {{if .SrcK8S_Type}}k8s:{{.SrcK8S_Type}}:{namespace: "{{.SrcK8S_Namespace}}", name: "{{.SrcK8S_Name}}"}{{end}}
 
   - name: NetflowToSrcK8sOwner
     start:
@@ -52,7 +52,7 @@ rules:
       classes: [ netflowOwner ]
     result:
       query: |-
-        k8s:{{.SrcK8S_OwnerType}}:{namespace: "{{.SrcK8S_Namespace}}", name: "{{.SrcK8S_OwnerName}}"}
+        {{if .SrcK8S_OwnerType}}k8s:{{.SrcK8S_OwnerType}}:{namespace: "{{.SrcK8S_Namespace}}", name: "{{.SrcK8S_OwnerName}}"}{{end}}
 
   - name: NetflowToDstK8s
     start:
@@ -62,7 +62,7 @@ rules:
       classes: [ netflowResource ]
     result:
       query: |-
-        k8s:{{.DstK8S_Type}}:{namespace: "{{.DstK8S_Namespace}}", name: "{{.DstK8S_Name}}"}
+        {{if .DstK8S_Type}}k8s:{{.DstK8S_Type}}:{namespace: "{{.DstK8S_Namespace}}", name: "{{.DstK8S_Name}}"}{{end}}
 
   - name: NetflowToDstK8sOwner
     start:
@@ -72,7 +72,7 @@ rules:
       classes: [ netflowOwner ]
     result:
       query: |-
-        k8s:{{.DstK8S_OwnerType}}:{namespace: "{{.DstK8S_Namespace}}", name: "{{.DstK8S_OwnerName}}"}
+        {{if .DstK8S_OwnerType}}k8s:{{.DstK8S_OwnerType}}:{namespace: "{{.DstK8S_Namespace}}", name: "{{.DstK8S_OwnerName}}"}{{end}}
 
   # K8s resources to related netflows.
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -30,8 +30,17 @@ const (
 	StoreKeyCA         = "certificateAuthority" // Path to CA certificate.
 )
 
-// Rule specifies a template rule.
-// It generates one or more korrel8r.Rule.
+// Rule configures a template rule.
+//
+// The rule template is applied to a instance of the start object.
+// It should generate one of the following:
+// - a goal query string of the form DOAMAIN:CLASS:QUERY_DATA.
+// - a blank (whitespace-only) string if the rule does not apply to the given object.
+// - an error if something unexpected goes wrong.
+//
+// If a rule returns an invalid query this will be logged as an error but will not prevent the
+// progress on other rules. For expected conditions, returning blank generates less noise than an
+// error.
 type Rule struct {
 	// Name is a short, descriptive name.
 	// If omitted, a name is generated from Start and Goal.

--- a/pkg/korrel8r/errors.go
+++ b/pkg/korrel8r/errors.go
@@ -3,6 +3,7 @@
 package korrel8r
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -25,4 +26,16 @@ type StoreNotFoundError struct {
 
 func (e StoreNotFoundError) Error() string {
 	return fmt.Sprintf("no stores found for domain %v", e.Domain)
+}
+
+// RuleSkipped is returned from Rule.Apply if the rule has pre-conditions that are not met by the starting object.
+// This signals an "expected" skipping of the rule, rather than a template error or returning a bad query.
+type RuleSkipped struct{ Rule Rule }
+
+func (e RuleSkipped) Error() string {
+	return fmt.Sprintf("rule skipped, not applicable: %v", e.Rule)
+}
+
+func IsRuleSkipped(err error) bool {
+	return errors.As(err, &RuleSkipped{})
 }

--- a/pkg/korrel8r/korrel8r.go
+++ b/pkg/korrel8r/korrel8r.go
@@ -136,7 +136,8 @@ type Appender interface{ Append(...Object) }
 // Rule describes a relationship for finding correlated objects.
 // Rule.Apply() generates correlated queries from start objects.
 //
-// Not required for a domain implementations: implemented by [github.com/korrel8r/korrel8r/pkg/rules]
+// Not required for a domain implementations.
+// Template-based rules are implemented by [github.com/korrel8r/korrel8r/pkg/rules]
 // Rules types must be comparable.
 type Rule interface {
 	// Apply the rule to a start Object, return a Query for results.

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -1,9 +1,12 @@
 // Copyright: This file is part of korrel8r, released under https://github.com/korrel8r/korrel8r/blob/main/LICENSE
 
-// Package rules uses templates to generate goal queries from start objects.
+// Package rules uses Go templates to generate goal queries from start objects.
+//
+// See [github.com/korrel8r/korrel8r/pkg/config.Rule] for details of configuring a rule.
 package rules
 
 import (
+	"strings"
 	"text/template"
 
 	"bytes"
@@ -35,6 +38,10 @@ func (r *templateRule) Apply(start korrel8r.Object) (korrel8r.Query, error) {
 	err := r.query.Execute(b, start)
 	if err != nil {
 		return nil, err
+	}
+	s := strings.TrimSpace(string(b.String()))
+	if s == "" { // Blank query means rule was skipped.
+		return nil, korrel8r.RuleSkipped{Rule: r}
 	}
 	return r.Goal()[0].Domain().Query(b.String())
 }


### PR DESCRIPTION
- A rule can check pre-conditions and return blank if it does not apply to an object.
  This will be ignored rather than logged as an error.
- Log similar rule evaluations with count rather than repetition.
- Log get operations with duration.