### PR TITLE
refactor!: rework object unmarshalling for all domains.

### DIFF
--- a/etc/korrel8r/rules/k8s_test.go
+++ b/etc/korrel8r/rules/k8s_test.go
@@ -18,8 +18,8 @@ import (
 func TestLogToPod(t *testing.T) {
 	e := setup()
 	for _, o := range []log.Object{
-		log.NewObject(`{"kubernetes":{"namespace_name":"foo","pod_name":"bar"}, "message":"hello"}`),
-		log.NewObject(`{"kubernetes":{"namespace_name":"default","pod_name":"baz"}, "message":"bye"}`),
+		log.FromLine(`{"kubernetes":{"namespace_name":"foo","pod_name":"bar"}, "message":"hello"}`),
+		log.FromLine(`{"kubernetes":{"namespace_name":"default","pod_name":"baz"}, "message":"bye"}`),
 	} {
 		t.Run(log.Preview(o), func(t *testing.T) {
 			k := o["kubernetes"].(map[string]any)

--- a/internal/pkg/test/mock/mock.go
+++ b/internal/pkg/test/mock/mock.go
@@ -24,6 +24,8 @@ var (
 	_ korrel8r.Store  = &Store{}
 )
 
+type Object any // mock.Object is any JSON-marshalable object.
+
 type Domain string
 
 func (d Domain) Name() string                          { return string(d) }
@@ -74,12 +76,12 @@ type Class struct {
 	domain korrel8r.Domain
 }
 
-func (c Class) Domain() korrel8r.Domain  { return c.domain }
-func (c Class) String() string           { return impl.ClassString(c) }
-func (c Class) Name() string             { return c.name }
-func (c Class) Description() string      { return fmt.Sprintf("mock class %v", c.String()) }
-func (c Class) ID(o korrel8r.Object) any { return o }
-func (c Class) New() korrel8r.Object     { return "" }
+func (c Class) Domain() korrel8r.Domain                     { return c.domain }
+func (c Class) String() string                              { return impl.ClassString(c) }
+func (c Class) Name() string                                { return c.name }
+func (c Class) Description() string                         { return fmt.Sprintf("mock class %v", c.String()) }
+func (c Class) ID(o korrel8r.Object) any                    { return o }
+func (c Class) Unmarshal(b []byte) (korrel8r.Object, error) { return impl.UnmarshalAs[Object](b) }
 
 type Rule struct {
 	name        string

--- a/internal/pkg/test/mock/store.go
+++ b/internal/pkg/test/mock/store.go
@@ -120,8 +120,8 @@ func (s *Store) LoadData(data []byte) error {
 		}
 		var result []korrel8r.Object
 		for _, r := range raw {
-			o := q.Class().New()
-			if err := yaml.Unmarshal(r, &o); err != nil {
+			o, err := q.Class().Unmarshal([]byte(r))
+			if err != nil {
 				return err
 			}
 			result = append(result, o)

--- a/pkg/domains/alert/alert.go
+++ b/pkg/domains/alert/alert.go
@@ -68,9 +68,8 @@ func (domain) Description() string         { return "Alerts that metric values a
 func (domain) Class(string) korrel8r.Class { return Class{} }
 func (domain) Classes() []korrel8r.Class   { return []korrel8r.Class{Class{}} }
 func (d domain) Query(s string) (korrel8r.Query, error) {
-	var q Query
-	_, err := impl.UnmarshalQueryString(d, s, &q)
-	return q, err
+	_, query, err := impl.UnmarshalQueryString[Query](d, s)
+	return query, err
 }
 
 const (
@@ -108,7 +107,7 @@ func (c Class) String() string          { return impl.ClassString(c) }
 func (c Class) Description() string {
 	return "An indication that some collection of metrics is outside of expected values."
 }
-func (c Class) New() korrel8r.Object { return &Object{} }
+func (c Class) Unmarshal(b []byte) (korrel8r.Object, error) { return impl.UnmarshalAs[Object](b) }
 func (c Class) ID(o korrel8r.Object) any {
 	if o, _ := o.(*Object); o != nil {
 		// The identity of an alert is defined by its labels.

--- a/pkg/domains/log/log.go
+++ b/pkg/domains/log/log.go
@@ -142,7 +142,7 @@ func (c Class) Description() string {
 	}
 }
 
-func (c Class) New() korrel8r.Object { return NewObject("") }
+func (c Class) Unmarshal(b []byte) (korrel8r.Object, error) { return impl.UnmarshalAs[Object](b) }
 
 // Preview extracts the message from a Viaq log record.
 func (c Class) Preview(x korrel8r.Object) (line string) { return Preview(x) }
@@ -158,12 +158,6 @@ func Preview(x korrel8r.Object) (line string) {
 
 // Object is a map in Viaq format.
 type Object map[string]any
-
-func NewObject(line string) Object {
-	var o Object
-	_ = json.Unmarshal([]byte(line), &o)
-	return o
-}
 
 func (o *Object) UnmarshalJSON(line []byte) error {
 	if err := json.Unmarshal([]byte(line), (*map[string]any)(o)); err != nil {
@@ -225,7 +219,7 @@ func (s *store) Get(ctx context.Context, query korrel8r.Query, constraint *korre
 	if err != nil {
 		return err
 	}
-	return s.Client.Get(ctx, q.Data(), constraint, func(e *loki.Entry) { result.Append(NewObject(e.Line)) })
+	return s.Client.Get(ctx, q.Data(), constraint, func(e *loki.Entry) { result.Append(FromLine(e.Line)) })
 }
 
 type stackStore struct{ store }
@@ -235,8 +229,10 @@ func (s *stackStore) Get(ctx context.Context, query korrel8r.Query, constraint *
 	if err != nil {
 		return err
 	}
-	return s.Client.GetStack(ctx, q.Data(), q.Class().Name(), constraint, func(e *loki.Entry) { result.Append(NewObject(e.Line)) })
+	return s.Client.GetStack(ctx, q.Data(), q.Class().Name(), constraint, func(e *loki.Entry) { result.Append(FromLine(e.Line)) })
 }
+
+func FromLine(line string) Object { o, _ := impl.UnmarshalAs[Object]([]byte(line)); return o }
 
 var logTypeRe = regexp.MustCompile(`{[^}]*log_type(=~*)"([^"]+)"}`)
 

--- a/pkg/domains/metric/metric.go
+++ b/pkg/domains/metric/metric.go
@@ -30,7 +30,6 @@
 package metric
 
 // TODO: doc comment needs to show model.Metric structure or link to it properly.
-// FIXME: metrics are only usable as goals.
 
 import (
 	"context"
@@ -83,12 +82,12 @@ func (domain) Store(s any) (korrel8r.Store, error) {
 
 type Class struct{} // Singleton class
 
-func (c Class) Domain() korrel8r.Domain          { return Domain }
-func (c Class) Name() string                     { return Domain.Name() }
-func (c Class) String() string                   { return impl.ClassString(c) }
-func (c Class) Description() string              { return "A set of label:value pairs identifying a time-series." }
-func (c Class) New() korrel8r.Object             { var obj Object; return obj }
-func (c Class) Preview(o korrel8r.Object) string { return Preview(o) }
+func (c Class) Domain() korrel8r.Domain                     { return Domain }
+func (c Class) Name() string                                { return Domain.Name() }
+func (c Class) String() string                              { return impl.ClassString(c) }
+func (c Class) Description() string                         { return "A set of label:value pairs identifying a time-series." }
+func (c Class) Unmarshal(b []byte) (korrel8r.Object, error) { return impl.UnmarshalAs[Object](b) }
+func (c Class) Preview(o korrel8r.Object) string            { return Preview(o) }
 
 type Object = model.Metric
 

--- a/pkg/domains/netflow/netflow.go
+++ b/pkg/domains/netflow/netflow.go
@@ -127,8 +127,9 @@ func (c Class) Domain() korrel8r.Domain { return Domain }
 func (c Class) Name() string            { return "network" }
 func (c Class) String() string          { return impl.ClassString(c) }
 func (c Class) Description() string     { return "A set of label:value pairs identifying a netflow." }
-
-func (c Class) New() korrel8r.Object { return NewObject(&loki.Entry{}) }
+func (c Class) Unmarshal(data []byte) (korrel8r.Object, error) {
+	return impl.UnmarshalAs[loki.Entry](data)
+}
 
 // Preview extracts the message from a Viaq log record.
 func (c Class) Preview(x korrel8r.Object) (line string) { return Preview(x) }

--- a/pkg/graph/helpers_test.go
+++ b/pkg/graph/helpers_test.go
@@ -3,40 +3,20 @@
 package graph
 
 import (
-	"fmt"
 	"slices"
+	"strconv"
 	"testing"
 
 	"github.com/korrel8r/korrel8r/internal/pkg/test/mock"
 	"github.com/korrel8r/korrel8r/pkg/korrel8r"
-	"github.com/korrel8r/korrel8r/pkg/korrel8r/impl"
 	"github.com/stretchr/testify/assert"
 )
 
-var Domain = domain{}
+var Domain = mock.Domain("graphmock")
 
 type rule = korrel8r.Rule
 
-type domain struct{}
-
-func (d domain) Name() string                         { return "graphmock" }
-func (d domain) String() string                       { return d.Name() }
-func (d domain) Description() string                  { return "" }
-func (d domain) Class(name string) korrel8r.Class     { panic("not implemented") }
-func (d domain) Classes() (classes []korrel8r.Class)  { panic("not implemented") }
-func (d domain) Query(string) (korrel8r.Query, error) { panic("not implemented") }
-func (d domain) Store(any) (korrel8r.Store, error)    { panic("not implemented") }
-
-type Class int
-
-func c(i int) korrel8r.Class { return Class(i) }
-
-func (c Class) Domain() korrel8r.Domain  { return Domain }
-func (c Class) Name() string             { return fmt.Sprintf("%v", int(c)) }
-func (c Class) String() string           { return impl.ClassString(c) }
-func (c Class) Description() string      { return "" }
-func (c Class) ID(o korrel8r.Object) any { return int(c) }
-func (c Class) New() korrel8r.Object     { panic("not implemented") }
+func c(i int) korrel8r.Class { return Domain.Class(strconv.Itoa(i)) }
 
 func testGraph(rules []korrel8r.Rule) *Graph {
 	d := NewData()

--- a/pkg/korrel8r/impl/impl.go
+++ b/pkg/korrel8r/impl/impl.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/korrel8r/korrel8r/pkg/korrel8r"
 	"sigs.k8s.io/yaml"
 )
 
@@ -23,33 +22,12 @@ func TypeAssert[T any](x any) (v T, err error) {
 	return v, err
 }
 
-// ParseQueryString parses a query string into class and data parts.
-func ParseQueryString(domain korrel8r.Domain, query string) (class korrel8r.Class, data string, err error) {
-	d, c, q := QuerySplit(query)
-	if q == "" {
-		return nil, "", fmt.Errorf("invalid query: %v", query)
-	}
-	if d != domain.Name() {
-		return nil, "", fmt.Errorf("wrong query domain, want %v: %v", domain, query)
-	}
-	class = domain.Class(c)
-	if class == nil {
-		return nil, "", korrel8r.ClassNotFoundError{Domain: domain, Class: c}
-	}
-	return class, q, nil
-}
+// Unmarshal JSON or YAML into a Go value using k8s YAML decoding (respect JSON tags).
+func Unmarshal(b []byte, data any) error { return yaml.UnmarshalStrict(b, data) }
 
-// UnmarshalQueryString unmarshals JSON query data as a Go map.
-func UnmarshalQueryString(domain korrel8r.Domain, query string, data any) (korrel8r.Class, error) {
-	c, qs, err := ParseQueryString(domain, query)
-	if err != nil {
-		return nil, err
-	}
-	if err := Unmarshal(qs, data); err != nil {
-		return c, fmt.Errorf("invalid query: %w: %v", err, qs)
-	}
-	return c, nil
+// UnmarshalAs is a generic typed version of [Unmarshal], returns the new value.
+func UnmarshalAs[T any](b []byte) (T, error) {
+	var v T
+	err := Unmarshal(b, &v)
+	return v, err
 }
-
-// Unmarshal a JSON or YAML string into a Go value.
-func Unmarshal(s string, data any) error { return yaml.UnmarshalStrict([]byte(s), data) }

--- a/pkg/korrel8r/impl/object.go
+++ b/pkg/korrel8r/impl/object.go
@@ -2,7 +2,9 @@
 
 package impl
 
-import "fmt"
+import (
+	"fmt"
+)
 
 func Preview[T any](o any, preview func(T) string) string {
 	if o, ok := o.(T); ok {

--- a/pkg/korrel8r/impl/query.go
+++ b/pkg/korrel8r/impl/query.go
@@ -1,0 +1,40 @@
+// Copyright: This file is part of korrel8r, released under https://github.com/korrel8r/korrel8r/blob/main/LICENSE
+
+package impl
+
+import (
+	"fmt"
+
+	"github.com/korrel8r/korrel8r/pkg/korrel8r"
+)
+
+// ParseQueryString parses a query string into class and data parts.
+func ParseQueryString(domain korrel8r.Domain, query string) (class korrel8r.Class, data string, err error) {
+	d, c, q := QuerySplit(query)
+	if q == "" {
+		return nil, "", fmt.Errorf("invalid query: %v", query)
+	}
+	if d != domain.Name() {
+		return nil, "", fmt.Errorf("wrong query domain, want %v: %v", domain, query)
+	}
+	class = domain.Class(c)
+	if class == nil {
+		return nil, "", korrel8r.ClassNotFoundError{Domain: domain, Class: c}
+	}
+	return class, q, nil
+}
+
+// UnmarshalQueryString unmarshals JSON query string to Go values.
+// T is the type to use to unmarshal the query data part.
+func UnmarshalQueryString[T any](domain korrel8r.Domain, query string) (korrel8r.Class, T, error) {
+	c, qs, err := ParseQueryString(domain, query)
+	var data T
+	if err != nil {
+		return nil, data, err
+	}
+	data, err = UnmarshalAs[T]([]byte(qs))
+	if err != nil {
+		return c, data, fmt.Errorf("invalid query: %w: %v", err, qs)
+	}
+	return c, data, nil
+}

--- a/pkg/korrel8r/korrel8r.go
+++ b/pkg/korrel8r/korrel8r.go
@@ -43,11 +43,11 @@ type Domain interface {
 //
 // Must be implemented by a korrel8r domain.
 type Class interface {
-	Domain() Domain      // Domain of this class.
-	Name() string        // Name of the class within the domain. Class names must not contain the character ':'.
-	String() string      // Fully qualified domain:class name
-	Description() string // Description for human-readable documentation.
-	New() Object         // Return a blank instance of the class, can be unmarshaled from JSON.
+	Domain() Domain                   // Domain of this class.
+	Name() string                     // Name of the class within the domain. Class names must not contain the character ':'.
+	String() string                   // Fully qualified domain:class name
+	Description() string              // Description for human-readable documentation.
+	Unmarshal([]byte) (Object, error) // Unmarshal an encoded object of the class type.
 }
 
 // Store is a source of signal data that can be queried.

--- a/pkg/rest/operations.go
+++ b/pkg/rest/operations.go
@@ -241,11 +241,11 @@ func (a *API) queries(c *gin.Context, queryStrings []string) (queries []korrel8r
 
 func (a *API) objects(c *gin.Context, class korrel8r.Class, raw []json.RawMessage) (objects []korrel8r.Object) {
 	for _, r := range raw {
-		obj := class.New()
-		if !check(c, http.StatusBadRequest, json.Unmarshal([]byte(r), &obj), "decoding object of class %v", class.String()) {
+		o, err := class.Unmarshal([]byte(r))
+		if !check(c, http.StatusBadRequest, err, "decoding object of class %v", class.String()) {
 			return nil
 		}
-		objects = append(objects, obj)
+		objects = append(objects, o)
 	}
 	return objects
 }

--- a/test/openshift/log_test.go
+++ b/test/openshift/log_test.go
@@ -30,7 +30,7 @@ func init() {
 func logObjects(lines []string) []korrel8r.Object {
 	logs := make([]korrel8r.Object, len(lines))
 	for i := range lines {
-		logs[i] = log.NewObject(lines[i])
+		logs[i] = log.FromLine(lines[i])
 	}
 	return logs
 }


### PR DESCRIPTION
Replace Class.New() with class.Unmarshal() to safely encapsulate type, pointer and choice of
unmarshalling library.

- helper functions in package impl
- updated all domain/* packages.