### PR TITLE
refactor: fix constraint logic, add timeout constraint.

### DIFF
--- a/cmd/korrel8r/get.go
+++ b/cmd/korrel8r/get.go
@@ -19,8 +19,8 @@ import (
 
 // getCmd represents the get command
 var (
-	sinceFlag, untilFlag *time.Duration
-	limitFlag            *uint
+	sinceFlag, untilFlag, timeoutFlag *time.Duration
+	limitFlag                         *int
 
 	getCmd = &cobra.Command{
 		Use:   "get DOMAIN:CLASS:QUERY",
@@ -31,9 +31,8 @@ var (
 			q := must.Must1(e.Query(args[0]))
 			result := newPrinter(os.Stdout)
 			c := &korrel8r.Constraint{}
-			if *limitFlag > 0 {
-				c.Limit = limitFlag
-			}
+			c.Limit = limitFlag
+			c.Timeout = timeoutFlag
 			now := time.Now()
 			if *sinceFlag > 0 {
 				c.Start = ptr.To(now.Add(-*sinceFlag))
@@ -47,8 +46,9 @@ var (
 )
 
 func init() {
+	limitFlag = getCmd.Flags().Int("limit", 0, "Limit total number of results.")
 	sinceFlag = getCmd.Flags().Duration("since", 0, "Only get results since this long ago.")
 	untilFlag = getCmd.Flags().Duration("until", 0, "Only get results until this long ago.")
-	limitFlag = getCmd.Flags().Uint("limit", 0, "Limit total number of results.")
+	timeoutFlag = getCmd.Flags().Duration("timeout", 0, "Timeout for store requests.")
 	rootCmd.AddCommand(getCmd)
 }

--- a/cmd/korrel8r/main.go
+++ b/cmd/korrel8r/main.go
@@ -80,10 +80,9 @@ func main() {
 func newEngine() (*engine.Engine, config.Configs) {
 	log.V(1).Info("loading configuration", "config", *configFlag)
 	c := must.Must1(config.Load(*configFlag))
-	e, err := engine.Build().
+	e := must.Must1(engine.Build().
 		Domains(k8s.Domain, logdomain.Domain, netflow.Domain, alert.Domain, metric.Domain, mock.Domain("mock")).
 		Config(c).
-		Engine()
-	must.Must(err)
+		Engine())
 	return e, c
 }

--- a/internal/pkg/test/mock/store.go
+++ b/internal/pkg/test/mock/store.go
@@ -74,8 +74,11 @@ func (s *Store) Get(ctx context.Context, q korrel8r.Query, constraint *korrel8r.
 	default:
 		result = []korrel8r.Object{data}
 	}
-	for _, o := range result {
-		if constraint == nil || s.ConstraintFunc == nil || s.ConstraintFunc(constraint, o) {
+	for i, o := range result {
+		if limit := constraint.GetLimit(); limit > 0 && i >= limit {
+			break
+		}
+		if s.ConstraintFunc == nil || constraint == nil || s.ConstraintFunc(constraint, o) {
 			r.Append(o)
 		}
 	}

--- a/pkg/domains/k8s/client.go
+++ b/pkg/domains/k8s/client.go
@@ -4,10 +4,10 @@ package k8s
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/go-logr/logr"
 	kconfig "github.com/korrel8r/korrel8r/pkg/config"
+	"github.com/korrel8r/korrel8r/pkg/korrel8r"
 	"github.com/korrel8r/korrel8r/pkg/rest/auth"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -52,9 +52,8 @@ func GetConfig() (*rest.Config, error) {
 		return nil, err
 	}
 	// TODO make these configurable.
-	cfg.QPS = 100
-	cfg.Burst = 1000
-	cfg.Timeout = 5 * time.Second
+	cfg.QPS = float32(korrel8r.DefaultLimit)
+	cfg.Burst = korrel8r.DefaultLimit
 	cfg.Wrap(auth.Wrap)
 	return cfg, nil
 }

--- a/pkg/domains/k8s/k8s.go
+++ b/pkg/domains/k8s/k8s.go
@@ -253,7 +253,7 @@ func (s *Store) Get(ctx context.Context, query korrel8r.Query, c *korrel8r.Const
 	if q.Name != "" { // Request for single object.
 		return s.getObject(ctx, q, appender)
 	} else {
-		return s.getList(ctx, q, appender)
+		return s.getList(ctx, q, appender, c)
 	}
 }
 
@@ -280,7 +280,7 @@ func (s *Store) getObject(ctx context.Context, q *Query, result korrel8r.Appende
 	return nil
 }
 
-func (s *Store) getList(ctx context.Context, q *Query, result korrel8r.Appender) error {
+func (s *Store) getList(ctx context.Context, q *Query, result korrel8r.Appender, c *korrel8r.Constraint) error {
 	gvk := q.class.GVK()
 	gvk.Kind = gvk.Kind + "List"
 	o, err := Scheme.New(gvk)
@@ -300,6 +300,9 @@ func (s *Store) getList(ctx context.Context, q *Query, result korrel8r.Appender)
 	}
 	if len(q.Fields) > 0 {
 		opts = append(opts, q.Fields)
+	}
+	if limit := c.GetLimit(); limit > 0 {
+		opts = append(opts, client.Limit(int64(limit)))
 	}
 	if err := s.c.List(ctx, list, opts...); err != nil {
 		return err

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -105,6 +105,11 @@ func (e *Engine) Graph() *graph.Graph { return graph.NewData(e.Rules()...).FullG
 // Get results for query from all stores for the query domain.
 func (e *Engine) Get(ctx context.Context, query korrel8r.Query, constraint *korrel8r.Constraint, result korrel8r.Appender) (err error) {
 	constraint = constraint.Default()
+	if timeout := constraint.GetTimeout(); timeout > 0 {
+		var cancel func()
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
 	defer func() {
 		if err != nil {
 			log.V(2).Info("Get failed", "error", err, "query", query, "constraint", constraint)

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -123,7 +123,9 @@ func TestEngine_PropagateConstraints(t *testing.T) {
 	early, ontime, late := start.Add(-1), start.Add(1), end.Add(1)
 	s := mock.NewStore(d)
 
-	s.ConstraintFunc = func(c *korrel8r.Constraint, o korrel8r.Object) bool { return c.CompareTime(o.(obj).Time) == 0 }
+	s.ConstraintFunc = func(c *korrel8r.Constraint, o korrel8r.Object) bool {
+		return c.CompareTime(o.(obj).Time) == 0
+	}
 
 	// Rules to test constraints.
 	e, err := Build().Rules(
@@ -139,17 +141,17 @@ func TestEngine_PropagateConstraints(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test traversals, verify constraints are applied.
-	for _, x := range []struct {
+	for i, x := range []struct {
 		constraint *korrel8r.Constraint
 		want       []obj
 	}{
+		{&korrel8r.Constraint{Start: &start, End: &end}, []obj{
+			{"vy", ontime},
+		}},
 		{&korrel8r.Constraint{End: &afterEnd}, []obj{
 			{"ux", early}, {"vx", ontime}, {"wx", late},
 			{"uy", early}, {"vy", ontime}, {"wy", late},
 			{"uz", early}, {"vz", ontime}, {"wz", late},
-		}},
-		{&korrel8r.Constraint{Start: &start, End: &end}, []obj{
-			{"vy", ontime},
 		}},
 		{&korrel8r.Constraint{Start: &start, End: &afterEnd}, []obj{
 			{"vy", ontime}, {"wy", late},
@@ -160,7 +162,7 @@ func TestEngine_PropagateConstraints(t *testing.T) {
 			{"uy", early}, {"vy", ontime},
 		}},
 	} {
-		t.Run(fmt.Sprintf("%+v", x.constraint), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
 			goals := []korrel8r.Class{c}
 			g := e.Graph().AllPaths(a, goals...)
 			g, err := e.GoalSearch(context.Background(), g, a, []korrel8r.Object{obj{"a", ontime}}, nil, x.constraint, goals)

--- a/pkg/korrel8r/constraint.go
+++ b/pkg/korrel8r/constraint.go
@@ -10,42 +10,83 @@ import (
 
 // Constraint included in a reference to restrict the resulting objects.
 type Constraint struct {
-	Limit *uint      `json:"limit,omitempty"` // Limit number of objects returned per query.
-	Start *time.Time `json:"start,omitempty"` // Start of time interval to include.
-	End   *time.Time `json:"end,omitempty"`   // End of time interval to include.
+	Limit   *int           `json:"limit,omitempty"`   // Limit number of objects returned per query, <=0 means no limit.
+	Timeout *time.Duration `json:"timeout,omitempty"` // Timeout per request.
+	Start   *time.Time     `json:"start,omitempty"`   // Start of time interval to include.
+	End     *time.Time     `json:"end,omitempty"`     // End of time interval to include.
 }
 
 // CompareTime returns -1 if t is before the constraint interval, +1 if it is after,
 // and 0 if it is in the interval, or if there is no interval.
 // Safe to call with c == nil
-func (c *Constraint) CompareTime(t time.Time) int {
+func (c *Constraint) CompareTime(when time.Time) int {
 	switch {
 	case c == nil:
 		return 0
-	case c.Start != nil && t.Before(*c.Start):
+	case c.Start != nil && when.Before(*c.Start):
 		return -1
-	case c.End != nil && t.After(*c.End):
+	case c.End != nil && when.After(*c.End):
 		return +1
 	}
 	return 0
 }
 
+// Default values can be modified in init() or main(), but not after korrel8r functions are called.
 var (
 	// DefaultDuration is the global default duration for query constraints.
 	DefaultDuration = time.Minute * 10
 	// DefaultLimit is the global default max items limit for query constraints.
-	DefaultLimit uint = 1000
+	DefaultLimit = 1000
+	// DefaultTimeout is default max timeout for queries.
+	DefaultTimeout = time.Second * 5
 )
 
-// Default returns a default constraint if c is nil, c otherwise.
+// Default fills in default values. Safe to call with c == nil.
 func (c *Constraint) Default() *Constraint {
 	if c == nil {
-		now := time.Now()
-		return &Constraint{
-			Start: ptr.To(now.Add(-DefaultDuration)),
-			End:   ptr.To(now),
-			Limit: ptr.To(DefaultLimit),
-		}
+		return (&Constraint{}).Default()
+	}
+	if c.Limit == nil {
+		c.Limit = ptr.To(DefaultLimit)
+	}
+	if c.Timeout == nil {
+		c.Timeout = ptr.To(DefaultTimeout)
+	}
+	if c.Start == nil || c.End == nil {
+		now := time.Now() // Avoid excessive calls to time.Now() on critical path.
+		c.Start = ptr.To(now.Add(-DefaultDuration))
+	}
+	if c.End == nil {
+		c.End = ptr.To(time.Now())
 	}
 	return c
+}
+
+// GetLimit returns limit or 0, safe to call with c == nil
+func (c *Constraint) GetLimit() int {
+	if c != nil && c.Limit != nil && *c.Limit > 0 {
+		return *c.Limit
+	}
+	return 0
+}
+
+func (c *Constraint) GetTimeout() time.Duration {
+	if c != nil && c.Timeout != nil && *c.Timeout > 0 {
+		return *c.Timeout
+	}
+	return 0
+}
+
+func (c *Constraint) GetStart() time.Time {
+	if c != nil && c.Start != nil {
+		return *c.Start
+	}
+	return time.Time{}
+}
+
+func (c *Constraint) GetEnd() time.Time {
+	if c != nil && c.End != nil {
+		return *c.End
+	}
+	return time.Time{}
 }

--- a/pkg/korrel8r/impl/store.go
+++ b/pkg/korrel8r/impl/store.go
@@ -1,0 +1,40 @@
+// Copyright: This file is part of korrel8r, released under https://github.com/korrel8r/korrel8r/blob/main/LICENSE
+
+package impl
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/korrel8r/korrel8r/internal/pkg/logging"
+)
+
+var log = logging.Log()
+
+// Get and decode a REST response, for stores that use raw HTTP clients.
+// body is decoded from the response, it must point to a JSON decodable type.
+func Get[T any](ctx context.Context, u *url.URL, hc *http.Client, body T) (err error) {
+	defer func() {
+		log.V(4).Info("GET", "url", u, "error", err)
+	}()
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := hc.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		if b, err := io.ReadAll(resp.Body); err == nil && len(b) > 0 {
+			return fmt.Errorf("%v: %v", resp.Status, string(b))
+		}
+		return fmt.Errorf("%v", resp.Status)
+	}
+	return json.NewDecoder(resp.Body).Decode(body)
+}

--- a/test/openshift/get_test.go
+++ b/test/openshift/get_test.go
@@ -1,0 +1,48 @@
+// Copyright: This file is part of korrel8r, released under https://github.com/korrel8r/korrel8r/blob/main/LICENSE
+
+package openshift
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/korrel8r/korrel8r/pkg/domains/alert"
+	"github.com/korrel8r/korrel8r/pkg/domains/k8s"
+	"github.com/korrel8r/korrel8r/pkg/domains/log"
+	"github.com/korrel8r/korrel8r/pkg/domains/metric"
+	"github.com/korrel8r/korrel8r/pkg/domains/netflow"
+	"github.com/korrel8r/korrel8r/pkg/engine"
+	"github.com/korrel8r/korrel8r/pkg/korrel8r"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGet(t *testing.T) {
+	e, err := engine.Build().
+		Domains(k8s.Domain, log.Domain, netflow.Domain, alert.Domain, metric.Domain).
+		ConfigFile("../../etc/korrel8r/openshift-route.yaml").
+		Engine()
+	require.NoError(t, err)
+	for _, q := range []string{
+		`k8s:Pod:{}`,
+		`log:infrastructure:{kubernetes_namespace_name=~".+"}`,
+		`metric:metric:{namespace="kube-system"}`,
+		`alert:alert:{severity: warning}`,
+		`netflow:network:{DstK8S_Namespace=~".+"}`,
+	} {
+		t.Run(q, func(t *testing.T) {
+			query, err := e.Query(q)
+			limit := 3
+			start := time.Now().Add(-time.Minute)
+			constraint := &korrel8r.Constraint{Limit: &limit, Start: &start}
+			r := korrel8r.NewResult(query.Class())
+			if assert.NoError(t, err) {
+				if assert.NoError(t, e.Get(context.Background(), query, constraint, r)) {
+					// FIXME stores for metric and alert domains ignore the limit. Need to fix.
+					assert.Equal(t, limit, len(r.List()), q)
+				}
+			}
+		})
+	}
+}

--- a/test/openshift/openshift.go
+++ b/test/openshift/openshift.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"net/url"
 
 	routev1 "github.com/openshift/api/route/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -58,14 +57,4 @@ func ServiceHost(ctx context.Context, c client.Client, nn types.NamespacedName) 
 	host := fmt.Sprintf("%v.%v.svc", nn.Name, nn.Namespace)
 	_, err := net.DefaultResolver.LookupHost(ctx, host)
 	return host, err
-}
-
-// ConsoleURL returns the base URL for the Openshift console on the current cluster.
-func ConsoleURL(ctx context.Context, c client.Client) (*url.URL, error) {
-	host, err := RouteHost(ctx, c, ConsoleNSName)
-	return &url.URL{
-		Scheme: "https",
-		Path:   "/",
-		Host:   host,
-	}, err
 }


### PR DESCRIPTION
- openshift/get_test.go: validate store Get against real stores.
- attempted to fix limit handling in metric domain, still a problem. See FIXME.
- individual defaulting of constraint values, user can force zero values.