### PR TITLE
fix #156: Enable errors for missing values in templates

### DIFF
--- a/etc/korrel8r/rules/netflow_test.go
+++ b/etc/korrel8r/rules/netflow_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/korrel8r/korrel8r/pkg/domains/k8s"
 	"github.com/korrel8r/korrel8r/pkg/domains/netflow"
-	"github.com/korrel8r/korrel8r/pkg/korrel8r"
 	"github.com/stretchr/testify/assert"
 	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -53,7 +52,7 @@ func Test_NetflowToK8S(t *testing.T) {
 }
 
 func Test_NetflowToK8S_skipped(t *testing.T) {
-	// Get correct error when rules are skipped (as opposed to a bad query or an error.)
+	// Get expected error when fields are missing.
 	e := setup()
 	for _, x := range []struct {
 		rule  string
@@ -85,8 +84,7 @@ func Test_NetflowToK8S_skipped(t *testing.T) {
 			tested(x.rule)
 			r := e.Rule(x.rule)
 			got, err := r.Apply(x.start)
-			assert.ErrorIs(t, err, korrel8r.RuleSkipped{Rule: r})
-			assert.True(t, korrel8r.IsRuleSkipped(err))
+			assert.ErrorContains(t, err, "map has no entry")
 			assert.Nil(t, got)
 		})
 	}

--- a/internal/pkg/tempo/tempo.go
+++ b/internal/pkg/tempo/tempo.go
@@ -105,7 +105,6 @@ func (c *Client) get(ctx context.Context, u *url.URL, collect CollectFunc) error
 
 	// Check for response status
 	if resp.StatusCode != http.StatusOK {
-		fmt.Println("Non-OK HTTP status:", resp.StatusCode)
 		return fmt.Errorf("%v", resp.Status)
 	}
 

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -121,6 +121,7 @@ func (e *Engine) Get(ctx context.Context, query korrel8r.Query, constraint *korr
 	defer func() {
 		if err != nil {
 			log.V(2).Info("Get failed", "error", err, "query", query, "constraint", constraint)
+			err = fmt.Errorf("Get failed: %v : %w", query, err)
 		}
 	}()
 	ss := e.stores[query.Class().Domain()]
@@ -199,7 +200,7 @@ func (e *Engine) query(query string) ([]korrel8r.Object, error) {
 func (e *Engine) NewTemplate(name string) *template.Template {
 	// missingkey defines behaviour on lookup of a non-existent map key.
 	// Returning a zero is more intuitive for rules than the arbitrary default "<no value>".
-	return template.New(name).Funcs(e.templateFuncs).Option("missingkey=zero")
+	return template.New(name).Funcs(e.templateFuncs).Option("missingkey=error")
 }
 
 // execTemplate is a convenience to call NewTemplate, execute the template and stringify the result.

--- a/pkg/engine/follower.go
+++ b/pkg/engine/follower.go
@@ -41,9 +41,7 @@ func (f *Follower) Traverse(l *graph.Line) bool {
 			count++
 			q, err := rule.Apply(s)
 			if err != nil {
-				if !korrel8r.IsRuleSkipped(err) { // Don't log deliberate skips.
-					log.V(2).Info("Apply error", "error", err, "id", korrel8r.GetID(start.Class, s))
-				}
+				log.V(3).Info("Apply error", "error", err, "id", korrel8r.GetID(start.Class, s))
 				continue
 			}
 			f.rules[key].Set(q, -1)

--- a/pkg/korrel8r/errors.go
+++ b/pkg/korrel8r/errors.go
@@ -3,7 +3,6 @@
 package korrel8r
 
 import (
-	"errors"
 	"fmt"
 )
 
@@ -26,16 +25,4 @@ type StoreNotFoundError struct {
 
 func (e StoreNotFoundError) Error() string {
 	return fmt.Sprintf("no stores found for domain %v", e.Domain)
-}
-
-// RuleSkipped is returned from Rule.Apply if the rule has pre-conditions that are not met by the starting object.
-// This signals an "expected" skipping of the rule, rather than a template error or returning a bad query.
-type RuleSkipped struct{ Rule Rule }
-
-func (e RuleSkipped) Error() string {
-	return fmt.Sprintf("rule skipped, not applicable: %v", e.Rule)
-}
-
-func IsRuleSkipped(err error) bool {
-	return errors.As(err, &RuleSkipped{})
 }

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -6,6 +6,7 @@
 package rules
 
 import (
+	"fmt"
 	"strings"
 	"text/template"
 
@@ -37,11 +38,11 @@ func (r *templateRule) Apply(start korrel8r.Object) (korrel8r.Query, error) {
 	b := &bytes.Buffer{}
 	err := r.query.Execute(b, start)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Error applying rule %v: %w", r, err)
 	}
-	s := strings.TrimSpace(string(b.String()))
-	if s == "" { // Blank query means rule was skipped.
-		return nil, korrel8r.RuleSkipped{Rule: r}
+	query := strings.TrimSpace(string(b.String()))
+	if query == "" { // Blank query means rule does not apply.
+		return nil, fmt.Errorf("No query from rule %v: %w", r, err)
 	}
-	return r.Goal()[0].Domain().Query(b.String())
+	return r.Goal()[0].Domain().Query(query)
 }


### PR DESCRIPTION
Otherwise Go templates put a useless "<no value>" string into queries,
which makes the query invalid and produces confusing secondary errors.