### PR TITLE
fix: always include start node in neighbours search

### DIFF
--- a/pkg/graph/helpers_test.go
+++ b/pkg/graph/helpers_test.go
@@ -18,6 +18,14 @@ type rule = korrel8r.Rule
 
 func c(i int) korrel8r.Class { return Domain.Class(strconv.Itoa(i)) }
 
+func nodesToInts(nodes []*Node) (ret []int) {
+	for _, n := range nodes {
+		i,_ := strconv.Atoi(n.Class.Name())
+		ret = append(ret, i)
+	}
+	return ret
+}
+
 func testGraph(rules []korrel8r.Rule) *Graph {
 	d := NewData()
 	for _, r := range rules {

--- a/pkg/graph/traverse.go
+++ b/pkg/graph/traverse.go
@@ -32,6 +32,7 @@ func (g *Graph) Traverse(start korrel8r.Class, goals []korrel8r.Class, f func(*L
 // Returns the subset of the graph that was traversed.
 func (g *Graph) Neighbours(start korrel8r.Class, depth int, f func(*Line) bool) (*Graph, error) {
 	sub := g.Data.EmptyGraph()
+	sub.AddNode(g.NodeFor(start))
 	atDepth := 0
 	current := unique.Set[int64]{} // Nodes at the current depth or above.
 


### PR DESCRIPTION
Previously was returning an empty graph if there were no neighbours.