### PR TITLE
fix: Detect bad k8s query missing space.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help: ## Display this help.
 	@grep -E '^## [A-Z0-9_]+: ' Makefile | sed 's/^## \([A-Z0-9_]*\): \(.*\)/\1#\2/' | column -s'#' -t
 
 ## VERSION: Semantic version for release, use -dev for development pre-release versions.
-VERSION?=0.7.4
+VERSION?=0.7.5-dev
 ## REGISTRY_BASE: Image registry base, for example quay.io/somebody
 REGISTRY_BASE?=$(error REGISTRY_BASE must be set to push images)
 ## IMGTOOL: May be podman or docker.

--- a/internal/pkg/test/mock/store.go
+++ b/internal/pkg/test/mock/store.go
@@ -113,7 +113,7 @@ func (s *Store) LoadFile(file string) error {
 // LoadData loads queries and results from bytes..
 func (s *Store) LoadData(data []byte) error {
 	loaded := map[string][]json.RawMessage{}
-	if err := yaml.Unmarshal(data, &loaded); err != nil {
+	if err := yaml.UnmarshalStrict(data, &loaded); err != nil {
 		return err
 	}
 	for qs, raw := range loaded {

--- a/pkg/domains/k8s/k8s_test.go
+++ b/pkg/domains/k8s/k8s_test.go
@@ -76,6 +76,22 @@ func TestDomain_Query(t *testing.T) {
 
 }
 
+func TestDomain_Query_error(t *testing.T) {
+	for _, x := range []struct {
+		s   string
+		err string
+	}{
+		// Detect common error: yaml map with missing space interpreted as key containing '"'
+		{`k8s:Namespace:{name:"foo"}`, "unknown field"},
+	} {
+		t.Run(x.s, func(t *testing.T) {
+			_, err := Domain.Query(x.s)
+			assert.ErrorContains(t, err, x.err)
+		})
+	}
+
+}
+
 func TestStore_Get(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithRESTMapper(testrestmapper.TestOnlyStaticRESTMapper(scheme.Scheme)).

--- a/pkg/korrel8r/impl/query.go
+++ b/pkg/korrel8r/impl/query.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/korrel8r/korrel8r/pkg/korrel8r"
-	yaml "sigs.k8s.io/yaml/goyaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 // ParseQuery parses a query string into class and data parts.
@@ -32,7 +32,7 @@ func UnmarshalQueryString[T any](domain korrel8r.Domain, query string) (c korrel
 	if err != nil {
 		return nil, data, err
 	}
-	err = yaml.Unmarshal([]byte(qs), &data)
+	err = yaml.UnmarshalStrict([]byte(qs), &data)
 	if err != nil {
 		return nil, data, fmt.Errorf("invalid query: %w: %v", err, qs)
 	}


### PR DESCRIPTION
Common error: `k8s:Pod:{namespace:"foo"}` (note missing space after ':')
was parsed as a YAML map with key `namespace:"foo"`

Use strict parsing to detect this error.