### PR TITLE
fix(COO-563): Korrel8r does not interrupt over-long queries.

### DIFF
--- a/doc/gen/rest_api.adoc
+++ b/doc/gen/rest_api.adoc
@@ -245,6 +245,8 @@ POST /api/v1alpha1/graphs/goals
 
 | link:#post-graphs-goals-200[200] | OK | OK |  | link:#post-graphs-goals-200-schema[schema]
 
+| link:#post-graphs-goals-206[206] | Partial Content | interrupted, partial result |  | link:#post-graphs-goals-206-schema[schema]
+
 | link:#post-graphs-goals-default[default] | |  |  | link:#post-graphs-goals-default-schema[schema]
 
 |===
@@ -257,6 +259,17 @@ POST /api/v1alpha1/graphs/goals
 Status: OK
 
 [id=post-graphs-goals-200-schema]
+====== Schema
+
+  
+
+link:#graph)[Graph]
+
+[id=post-graphs-goals-206]
+=====  206 - interrupted, partial result
+Status: Partial Content
+
+[id=post-graphs-goals-206-schema]
 ====== Schema
 
   
@@ -308,6 +321,8 @@ POST /api/v1alpha1/graphs/neighbours
 
 | link:#post-graphs-neighbours-200[200] | OK | OK |  | link:#post-graphs-neighbours-200-schema[schema]
 
+| link:#post-graphs-neighbours-206[206] | Partial Content | interrupted, partial result |  | link:#post-graphs-neighbours-206-schema[schema]
+
 | link:#post-graphs-neighbours-default[default] | |  |  | link:#post-graphs-neighbours-default-schema[schema]
 
 |===
@@ -320,6 +335,17 @@ POST /api/v1alpha1/graphs/neighbours
 Status: OK
 
 [id=post-graphs-neighbours-200-schema]
+====== Schema
+
+  
+
+link:#graph)[Graph]
+
+[id=post-graphs-neighbours-206]
+=====  206 - interrupted, partial result
+Status: Partial Content
+
+[id=post-graphs-neighbours-206-schema]
 ====== Schema
 
   

--- a/pkg/config/duration.go
+++ b/pkg/config/duration.go
@@ -1,0 +1,38 @@
+// Copyright: This file is part of korrel8r, released under https://github.com/korrel8r/korrel8r/blob/main/LICENSE
+
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+type Duration struct {
+	time.Duration
+}
+
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
+}
+
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	var v any
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	switch v := v.(type) {
+	case float64:
+		d.Duration = time.Duration(v * float64(time.Second))
+		return nil
+	case string:
+		var err error
+		d.Duration, err = time.ParseDuration(v)
+		if err != nil {
+			return err
+		}
+		return nil
+	default:
+		return errors.New("invalid duration")
+	}
+}

--- a/pkg/config/testdata/bad-tuning.json
+++ b/pkg/config/testdata/bad-tuning.json
@@ -1,0 +1,4 @@
+{
+  "include": [ "config.json"],
+  "tuning": { "requestTimeout": "99s"}
+}

--- a/pkg/config/testdata/config.json
+++ b/pkg/config/testdata/config.json
@@ -1,1 +1,4 @@
-{ "include": [ "config1.yaml",  "config.json", "config2.yaml" ] }
+{
+  "include": [ "config1.yaml",  "config.json", "config2.yaml" ],
+  "tuning": { "requestTimeout": "1s"}
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -16,7 +16,16 @@ type Config struct {
 
 	// Include lists additional configuration files or URLs to include.
 	Include []string `json:"include,omitempty"`
+
+	// Tuning section has limits and optimizations.
+	Tuning *Tuning `json:"tuning,omitempty"`
+
+	// Soure of configuration, file or URL.
+	Source string `json:"-"`
 }
+
+// Configs is a list of configs from different sources.
+type Configs []Config
 
 // Store is a map of name:value attributes used to connect to a store.
 // The names and values depend on the type of store.
@@ -83,4 +92,11 @@ type Class struct {
 	Domain string `json:"domain"`
 	// Classes are the names of classes in this group.
 	Classes []string `json:"classes"`
+}
+
+// Tuning section for limits and optimizations.
+type Tuning struct {
+	// RequestTimeout cancel requests if they last longer than this timeout.
+	// Cancelling a correlation operation may return an error or a partial result (HTTP 206).
+	RequestTimeout Duration `json:"requestTimeout,omitempty"`
 }

--- a/pkg/engine/builder.go
+++ b/pkg/engine/builder.go
@@ -108,11 +108,8 @@ func (b *Builder) Config(configs config.Configs) *Builder {
 	if b.err != nil {
 		return b
 	}
-	if b.err = configs.Expand(); b.err != nil {
-		return b
-	}
 	for source, c := range configs {
-		b.config(source, c)
+		b.config(c.Source, &c)
 		if b.err != nil {
 			b.err = fmt.Errorf("%v: %w", source, b.err)
 			return b

--- a/pkg/korrel8r/constraint.go
+++ b/pkg/korrel8r/constraint.go
@@ -37,8 +37,8 @@ var (
 	DefaultDuration = time.Hour
 	// DefaultLimit is the global default max items limit for query constraints.
 	DefaultLimit = 1000
-	// DefaultTimeout is default max timeout for queries.
-	DefaultTimeout = time.Second * 5
+	// DefaultTimeout is default max timeout for requests and queries.
+	DefaultTimeout = time.Second * 10
 )
 
 // Default fills in default values. Safe to call with c == nil.

--- a/pkg/rest/docs/docs.go
+++ b/pkg/rest/docs/docs.go
@@ -129,6 +129,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/Graph"
                         }
                     },
+                    "206": {
+                        "description": "interrupted, partial result",
+                        "schema": {
+                            "$ref": "#/definitions/Graph"
+                        }
+                    },
                     "default": {
                         "description": "",
                         "schema": {
@@ -161,6 +167,12 @@ const docTemplate = `{
                 "responses": {
                     "200": {
                         "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/Graph"
+                        }
+                    },
+                    "206": {
+                        "description": "interrupted, partial result",
                         "schema": {
                             "$ref": "#/definitions/Graph"
                         }

--- a/pkg/rest/docs/swagger.json
+++ b/pkg/rest/docs/swagger.json
@@ -127,6 +127,12 @@
                             "$ref": "#/definitions/Graph"
                         }
                     },
+                    "206": {
+                        "description": "interrupted, partial result",
+                        "schema": {
+                            "$ref": "#/definitions/Graph"
+                        }
+                    },
                     "default": {
                         "description": "",
                         "schema": {
@@ -159,6 +165,12 @@
                 "responses": {
                     "200": {
                         "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/Graph"
+                        }
+                    },
+                    "206": {
+                        "description": "interrupted, partial result",
                         "schema": {
                             "$ref": "#/definitions/Graph"
                         }

--- a/pkg/rest/docs/swagger.yaml
+++ b/pkg/rest/docs/swagger.yaml
@@ -227,6 +227,10 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/Graph'
+        "206":
+          description: interrupted, partial result
+          schema:
+            $ref: '#/definitions/Graph'
         default:
           description: ""
           schema:
@@ -248,6 +252,10 @@ paths:
       responses:
         "200":
           description: OK
+          schema:
+            $ref: '#/definitions/Graph'
+        "206":
+          description: interrupted, partial result
           schema:
             $ref: '#/definitions/Graph'
         default:

--- a/pkg/rest/helpers.go
+++ b/pkg/rest/helpers.go
@@ -39,6 +39,9 @@ func node(n *graph.Node) Node {
 }
 
 func nodes(g *graph.Graph) []Node {
+	if g == nil {
+		return nil
+	}
 	nodes := []Node{} // Want [] not null for empty in JSON.
 	g.EachNode(func(n *graph.Node) {
 		if !n.Empty() { // Skip empty nodes
@@ -64,6 +67,9 @@ func edge(e *graph.Edge, rules bool) Edge {
 }
 
 func edges(g *graph.Graph, opts *Options) (edges []Edge) {
+	if g == nil {
+		return nil
+	}
 	g.EachEdge(func(e *graph.Edge) {
 		if !e.Goal().Empty() { // Skip edges that lead to an empty node.
 			edges = append(edges, edge(e, opts.Rules))


### PR DESCRIPTION
- Add configurable tuning.requestTimetout (default 10s)
- Set context timeout on each incoming request.
- Return 206 (partial resource) if timeout is exceeded.

https://issues.redhat.com/browse/COO-563