### PR TITLE
feat: Added profiling and goals, neighbours commands.

### DIFF
--- a/cmd/korrel8r/get.go
+++ b/cmd/korrel8r/get.go
@@ -8,19 +8,18 @@ package main
 import (
 	"context"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/korrel8r/korrel8r/internal/pkg/must"
+	"github.com/korrel8r/korrel8r/pkg/engine/traverse"
 	"github.com/korrel8r/korrel8r/pkg/korrel8r"
 	"github.com/korrel8r/korrel8r/pkg/ptr"
+	"github.com/korrel8r/korrel8r/pkg/rest"
 	"github.com/spf13/cobra"
 )
 
-// getCmd represents the get command
 var (
-	sinceFlag, untilFlag, timeoutFlag *time.Duration
-	limitFlag                         *int
-
 	getCmd = &cobra.Command{
 		Use:   "get DOMAIN:CLASS:QUERY",
 		Short: "Execute QUERY and print the results",
@@ -29,29 +28,96 @@ var (
 			e, _ := newEngine()
 			q := must.Must1(e.Query(args[0]))
 			result := newPrinter(os.Stdout)
-			c := &korrel8r.Constraint{}
-			if *limitFlag > 0 {
-				c.Limit = limitFlag
-			}
-			if *timeoutFlag > 0 {
-				c.Timeout = timeoutFlag
-			}
-			now := time.Now()
-			if *sinceFlag > 0 {
-				c.Start = ptr.To(now.Add(-*sinceFlag))
-			}
-			if *untilFlag > 0 {
-				c.End = ptr.To(now.Add(-*untilFlag))
-			}
+			c := getFlags.Constraint()
 			must.Must(e.Get(context.Background(), q, c, result))
 		},
 	}
+	getFlags *constraintFlags
 )
 
 func init() {
-	limitFlag = getCmd.Flags().Int("limit", 0, "Limit total number of results.")
-	sinceFlag = getCmd.Flags().Duration("since", 0, "Only get results since this long ago.")
-	untilFlag = getCmd.Flags().Duration("until", 0, "Only get results until this long ago.")
-	timeoutFlag = getCmd.Flags().Duration("timeout", 0, "Timeout for store requests.")
+	getFlags = newConstraintFlags(getCmd)
 	rootCmd.AddCommand(getCmd)
+}
+
+var (
+	neighboursCmd = &cobra.Command{
+		Use:   "neighbours DOMAIN:CLASS:QUERY [DEPTH]",
+		Short: "Execute QUERY, compute a neighbourhood of the results up to DEPTH.",
+		Args:  cobra.RangeArgs(1, 2),
+		Run: func(cmd *cobra.Command, args []string) {
+			e, _ := newEngine()
+			q := must.Must1(e.Query(args[0]))
+			d := 3
+			if len(args) == 2 {
+				d = must.Must1(strconv.Atoi(args[1]))
+			}
+			ctx := korrel8r.WithConstraint(context.Background(), neighboursFlags.Constraint())
+			g := must.Must1(traverse.New(e, e.Graph()).Neighbours(ctx, traverse.Start{Class: q.Class(), Queries: []korrel8r.Query{q}}, d))
+			newPrinter(os.Stdout).Print(rest.NewGraph(g))
+		},
+	}
+	neighboursFlags *constraintFlags
+)
+
+func init() {
+	neighboursFlags = newConstraintFlags(neighboursCmd)
+	rootCmd.AddCommand(neighboursCmd)
+}
+
+var (
+	goalsCmd = &cobra.Command{
+		Use:   "goals DOMAIN:CLASS:QUERY [GOAL...]",
+		Short: "Execute QUERY, find all paths to GOAL classes.",
+		Args:  cobra.MinimumNArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			e, _ := newEngine()
+			q := must.Must1(e.Query(args[0]))
+			var goals []korrel8r.Class
+			for _, g := range args[1:] {
+				goals = append(goals, must.Must1(e.Class(g)))
+			}
+			ctx := korrel8r.WithConstraint(context.Background(), goalsFlags.Constraint())
+			g := must.Must1(traverse.New(e, e.Graph()).Goals(ctx, traverse.Start{Class: q.Class(), Queries: []korrel8r.Query{q}}, goals))
+			newPrinter(os.Stdout).Print(rest.NewGraph(g))
+		},
+	}
+	goalsFlags *constraintFlags
+)
+
+func init() {
+	goalsFlags = newConstraintFlags(goalsCmd)
+	rootCmd.AddCommand(goalsCmd)
+}
+
+type constraintFlags struct {
+	sinceFlag, untilFlag, timeoutFlag *time.Duration
+	limitFlag                         *int
+}
+
+func newConstraintFlags(cmd *cobra.Command) *constraintFlags {
+	cf := &constraintFlags{}
+	cf.limitFlag = cmd.Flags().Int("limit", 0, "Limit total number of results.")
+	cf.sinceFlag = cmd.Flags().Duration("since", 0, "Only get results since this long ago.")
+	cf.untilFlag = cmd.Flags().Duration("until", 0, "Only get results until this long ago.")
+	cf.timeoutFlag = cmd.Flags().Duration("timeout", 0, "Timeout for store requests.")
+	return cf
+}
+
+func (cf *constraintFlags) Constraint() *korrel8r.Constraint {
+	c := &korrel8r.Constraint{}
+	if *cf.limitFlag > 0 {
+		c.Limit = cf.limitFlag
+	}
+	if *cf.timeoutFlag > 0 {
+		c.Timeout = cf.timeoutFlag
+	}
+	now := time.Now()
+	if *cf.sinceFlag > 0 {
+		c.Start = ptr.To(now.Add(-*cf.sinceFlag))
+	}
+	if *cf.untilFlag > 0 {
+		c.End = ptr.To(now.Add(-*cf.untilFlag))
+	}
+	return c
 }

--- a/cmd/korrel8r/profile.go
+++ b/cmd/korrel8r/profile.go
@@ -1,0 +1,48 @@
+// Copyright: This file is part of korrel8r, released under https://github.com/korrel8r/korrel8r/blob/main/LICENSE
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pkg/profile"
+)
+
+const (
+	profileEnv     = "KORREL8R_PROFILE"
+	profilePathEnv = "KORREL8R_PROFILE_PATH"
+)
+
+var (
+	profileFlag     = rootCmd.PersistentFlags().String("profile", os.Getenv(profileEnv), "Enable profiling, one of [block, cpu, goroutine, mem, alloc, heap, mutex, clock, http]")
+	profilePathFlag = rootCmd.PersistentFlags().String("profilePath", os.Getenv(profilePathEnv), "Output path for profile")
+)
+
+type noopStop struct{}
+
+func (noopStop) Stop() {}
+
+func StartProfile() interface{ Stop() } {
+	flags := map[string]func(*profile.Profile){
+		"block":     profile.BlockProfile,
+		"cpu":       profile.CPUProfile,
+		"goroutine": profile.GoroutineProfile,
+		"mem":       profile.MemProfile,
+		"alloc":     profile.MemProfileAllocs,
+		"heap":      profile.MemProfileHeap,
+		"mutex":     profile.MutexProfile,
+		"clock":     profile.ClockProfile,
+		"trace":     profile.TraceProfile,
+	}
+	if opt, ok := flags[*profileFlag]; ok {
+		if *profilePathFlag == "" {
+			*profilePathFlag = "."
+		}
+		return profile.Start(profile.ProfilePath(*profilePathFlag), opt)
+	}
+	if *profileFlag != "" {
+		panic(fmt.Errorf("Invalid value for --profile flag: %v", *profileFlag))
+	}
+	return noopStop{}
+}

--- a/cmd/korrel8r/web.go
+++ b/cmd/korrel8r/web.go
@@ -6,9 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strconv"
 
-	"github.com/gin-contrib/pprof"
 	"github.com/gin-gonic/gin"
 	"github.com/korrel8r/korrel8r/internal/pkg/build"
 	"github.com/korrel8r/korrel8r/internal/pkg/must"
@@ -62,9 +60,10 @@ var webCmd = &cobra.Command{
 		must.Must(err)
 		defer r.Close()
 		s.Handler = router
-		if *profileFlag {
-			pprof.Register(router)
+		if *profileFlag == "http" {
+			rest.WebProfile(router)
 		}
+		log.Info("Starting korrel8r", "version", build.Version, "configuration", *configFlag)
 		if *httpFlag != "" {
 			log.Info("listening for http", "addr", s.Addr, "version", build.Version)
 			must.Must(s.ListenAndServe())
@@ -79,11 +78,7 @@ var (
 	httpFlag, httpsFlag *string
 	certFlag, keyFlag   *string
 	specFlag            *string
-	profileFlag         *bool
-)
-
-const (
-	profileEnv = "KORREL8R_PROFILE"
+	WebProfile          func()
 )
 
 func init() {
@@ -93,6 +88,4 @@ func init() {
 	certFlag = webCmd.Flags().String("cert", "", "TLS certificate file (PEM format) for https")
 	keyFlag = webCmd.Flags().String("key", "", "Private key (PEM format) for https")
 	specFlag = webCmd.Flags().String("spec", "", "Dump swagger spec to a file, '-' for stdout.")
-	profileDefault, _ := strconv.ParseBool(os.Getenv(profileEnv))
-	profileFlag = webCmd.Flags().Bool("profile", profileDefault, "Enable HTTP profiling, see https://pkg.go.dev/net/http/pprof")
 }

--- a/doc/gen/cmd/korrel8r.adoc
+++ b/doc/gen/cmd/korrel8r.adoc
@@ -5,17 +5,21 @@ REST service to correlate observability data
 == Options
 
 ----
-  -c, --config string   Configuration file (default "/etc/korrel8r/korrel8r.yaml")
-  -h, --help            help for korrel8r
-  -o, --output string   Output format: [json, json-pretty, yaml] (default "yaml")
-  -v, --verbose int     Verbosity for logging (0: notice/error/warn, 1: info, 2: debug, 3+: trace)
+  -c, --config string        Configuration file (default "/etc/korrel8r/korrel8r.yaml")
+  -h, --help                 help for korrel8r
+  -o, --output string        Output format: [json, json-pretty, yaml] (default "yaml")
+      --profile string       Enable profiling, one of [block, cpu, goroutine, mem, alloc, heap, mutex, clock, http]
+      --profilePath string   Output path for profile
+  -v, --verbose int          Verbosity for logging (0: notice/error/warn, 1: info, 2: debug, 3+: trace)
 ----
 
 == SEE ALSO
 
 * xref:korrel8r_describe.adoc[korrel8r describe]	 - Describe NAME, which can be a domain or class name.
 * xref:korrel8r_get.adoc[korrel8r get]	 - Execute QUERY and print the results
+* xref:korrel8r_goals.adoc[korrel8r goals]	 - Execute QUERY, find all paths to GOAL classes.
 * xref:korrel8r_list.adoc[korrel8r list]	 - List domains or classes in DOMAIN.
+* xref:korrel8r_neighbours.adoc[korrel8r neighbours]	 - Execute QUERY, compute a neighbourhood of the results up to DEPTH.
 * xref:korrel8r_rules.adoc[korrel8r rules]	 - List rules by start, goal or name
 * xref:korrel8r_template.adoc[korrel8r template]	 - Apply a Go template to the korrel8r engine.
 * xref:korrel8r_web.adoc[korrel8r web]	 - Start REST server. Listening address must be  provided via --http or --https.

--- a/doc/gen/cmd/korrel8r_describe.adoc
+++ b/doc/gen/cmd/korrel8r_describe.adoc
@@ -15,9 +15,11 @@ korrel8r describe NAME [flags]
 == Options inherited from parent commands
 
 ----
-  -c, --config string   Configuration file (default "/etc/korrel8r/korrel8r.yaml")
-  -o, --output string   Output format: [json, json-pretty, yaml] (default "yaml")
-  -v, --verbose int     Verbosity for logging (0: notice/error/warn, 1: info, 2: debug, 3+: trace)
+  -c, --config string        Configuration file (default "/etc/korrel8r/korrel8r.yaml")
+  -o, --output string        Output format: [json, json-pretty, yaml] (default "yaml")
+      --profile string       Enable profiling, one of [block, cpu, goroutine, mem, alloc, heap, mutex, clock, http]
+      --profilePath string   Output path for profile
+  -v, --verbose int          Verbosity for logging (0: notice/error/warn, 1: info, 2: debug, 3+: trace)
 ----
 
 == SEE ALSO

--- a/doc/gen/cmd/korrel8r_get.adoc
+++ b/doc/gen/cmd/korrel8r_get.adoc
@@ -19,9 +19,11 @@ korrel8r get DOMAIN:CLASS:QUERY [flags]
 == Options inherited from parent commands
 
 ----
-  -c, --config string   Configuration file (default "/etc/korrel8r/korrel8r.yaml")
-  -o, --output string   Output format: [json, json-pretty, yaml] (default "yaml")
-  -v, --verbose int     Verbosity for logging (0: notice/error/warn, 1: info, 2: debug, 3+: trace)
+  -c, --config string        Configuration file (default "/etc/korrel8r/korrel8r.yaml")
+  -o, --output string        Output format: [json, json-pretty, yaml] (default "yaml")
+      --profile string       Enable profiling, one of [block, cpu, goroutine, mem, alloc, heap, mutex, clock, http]
+      --profilePath string   Output path for profile
+  -v, --verbose int          Verbosity for logging (0: notice/error/warn, 1: info, 2: debug, 3+: trace)
 ----
 
 == SEE ALSO

--- a/doc/gen/cmd/korrel8r_goals.adoc
+++ b/doc/gen/cmd/korrel8r_goals.adoc
@@ -1,20 +1,19 @@
-= korrel8r web
+= korrel8r goals
 
-Start REST server. Listening address must be  provided via --http or --https.
+Execute QUERY, find all paths to GOAL classes.
 
 ----
-korrel8r web [flags]
+korrel8r goals DOMAIN:CLASS:QUERY [GOAL...] [flags]
 ----
 
 == Options
 
 ----
-      --cert string    TLS certificate file (PEM format) for https
-  -h, --help           help for web
-      --http string    host:port address for insecure http listener
-      --https string   host:port address for secure https listener
-      --key string     Private key (PEM format) for https
-      --spec string    Dump swagger spec to a file, '-' for stdout.
+  -h, --help               help for goals
+      --limit int          Limit total number of results.
+      --since duration     Only get results since this long ago.
+      --timeout duration   Timeout for store requests.
+      --until duration     Only get results until this long ago.
 ----
 
 == Options inherited from parent commands

--- a/doc/gen/cmd/korrel8r_list.adoc
+++ b/doc/gen/cmd/korrel8r_list.adoc
@@ -15,9 +15,11 @@ korrel8r list [DOMAIN] [flags]
 == Options inherited from parent commands
 
 ----
-  -c, --config string   Configuration file (default "/etc/korrel8r/korrel8r.yaml")
-  -o, --output string   Output format: [json, json-pretty, yaml] (default "yaml")
-  -v, --verbose int     Verbosity for logging (0: notice/error/warn, 1: info, 2: debug, 3+: trace)
+  -c, --config string        Configuration file (default "/etc/korrel8r/korrel8r.yaml")
+  -o, --output string        Output format: [json, json-pretty, yaml] (default "yaml")
+      --profile string       Enable profiling, one of [block, cpu, goroutine, mem, alloc, heap, mutex, clock, http]
+      --profilePath string   Output path for profile
+  -v, --verbose int          Verbosity for logging (0: notice/error/warn, 1: info, 2: debug, 3+: trace)
 ----
 
 == SEE ALSO

--- a/doc/gen/cmd/korrel8r_neighbours.adoc
+++ b/doc/gen/cmd/korrel8r_neighbours.adoc
@@ -1,20 +1,19 @@
-= korrel8r web
+= korrel8r neighbours
 
-Start REST server. Listening address must be  provided via --http or --https.
+Execute QUERY, compute a neighbourhood of the results up to DEPTH.
 
 ----
-korrel8r web [flags]
+korrel8r neighbours DOMAIN:CLASS:QUERY [DEPTH] [flags]
 ----
 
 == Options
 
 ----
-      --cert string    TLS certificate file (PEM format) for https
-  -h, --help           help for web
-      --http string    host:port address for insecure http listener
-      --https string   host:port address for secure https listener
-      --key string     Private key (PEM format) for https
-      --spec string    Dump swagger spec to a file, '-' for stdout.
+  -h, --help               help for neighbours
+      --limit int          Limit total number of results.
+      --since duration     Only get results since this long ago.
+      --timeout duration   Timeout for store requests.
+      --until duration     Only get results until this long ago.
 ----
 
 == Options inherited from parent commands

--- a/doc/gen/cmd/korrel8r_rules.adoc
+++ b/doc/gen/cmd/korrel8r_rules.adoc
@@ -19,9 +19,11 @@ korrel8r rules [flags]
 == Options inherited from parent commands
 
 ----
-  -c, --config string   Configuration file (default "/etc/korrel8r/korrel8r.yaml")
-  -o, --output string   Output format: [json, json-pretty, yaml] (default "yaml")
-  -v, --verbose int     Verbosity for logging (0: notice/error/warn, 1: info, 2: debug, 3+: trace)
+  -c, --config string        Configuration file (default "/etc/korrel8r/korrel8r.yaml")
+  -o, --output string        Output format: [json, json-pretty, yaml] (default "yaml")
+      --profile string       Enable profiling, one of [block, cpu, goroutine, mem, alloc, heap, mutex, clock, http]
+      --profilePath string   Output path for profile
+  -v, --verbose int          Verbosity for logging (0: notice/error/warn, 1: info, 2: debug, 3+: trace)
 ----
 
 == SEE ALSO

--- a/doc/gen/cmd/korrel8r_template.adoc
+++ b/doc/gen/cmd/korrel8r_template.adoc
@@ -23,9 +23,11 @@ korrel8r template [--file FILE|--template STRING] [flags]
 == Options inherited from parent commands
 
 ----
-  -c, --config string   Configuration file (default "/etc/korrel8r/korrel8r.yaml")
-  -o, --output string   Output format: [json, json-pretty, yaml] (default "yaml")
-  -v, --verbose int     Verbosity for logging (0: notice/error/warn, 1: info, 2: debug, 3+: trace)
+  -c, --config string        Configuration file (default "/etc/korrel8r/korrel8r.yaml")
+  -o, --output string        Output format: [json, json-pretty, yaml] (default "yaml")
+      --profile string       Enable profiling, one of [block, cpu, goroutine, mem, alloc, heap, mutex, clock, http]
+      --profilePath string   Output path for profile
+  -v, --verbose int          Verbosity for logging (0: notice/error/warn, 1: info, 2: debug, 3+: trace)
 ----
 
 == SEE ALSO

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/openshift/api v0.0.0-20241001152557-e415140e5d5f
 	github.com/operator-framework/api v0.27.0
+	github.com/pkg/profile v1.7.0
 	github.com/prometheus/alertmanager v0.27.0
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/common v0.60.1
@@ -36,6 +37,8 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dennwc/varint v1.0.0 // indirect
+	github.com/felixge/fgprof v0.9.3 // indirect
+	github.com/google/pprof v0.0.0-20240711041743-f6c9dda6c6da // indirect
 	github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	go.uber.org/atomic v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,9 @@ github.com/bytedance/sonic/loader v0.1.1 h1:c+e5Pt1k/cy5wMveRDyk2X4B9hF4g7an8N3z
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cloudwego/base64x v0.1.4 h1:jwCgWpFanWmN8xoIUHa2rtzmkd5J2plF/dnLS6Xd/0Y=
 github.com/cloudwego/base64x v0.1.4/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJgA0rcu/8w=
 github.com/cloudwego/iasm v0.2.0 h1:1KNIy1I1H9hNNFEEH3DVnI4UujN+1zjpuk6gwHLTssg=
@@ -60,6 +63,8 @@ github.com/emicklei/go-restful/v3 v3.11.2 h1:1onLa9DcsMYO9P+CXaL0dStDqQ2EHHXLiz+
 github.com/emicklei/go-restful/v3 v3.11.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=
 github.com/evanphx/json-patch/v5 v5.9.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
+github.com/felixge/fgprof v0.9.3 h1:VvyZxILNuCiUCSXtPtYmmtGvb65nqXh2QFWc0Wpf2/g=
+github.com/felixge/fgprof v0.9.3/go.mod h1:RdbpDgzqYVh/T9fPELJyV7EYJuHB55UTEULNun8eiPw=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -133,6 +138,7 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/pprof v0.0.0-20211214055906-6f57359322fd/go.mod h1:KgnwoLYCZ8IQu3XUZ8Nc/bM9CCZFOyjUNOSygVozoDg=
 github.com/google/pprof v0.0.0-20240711041743-f6c9dda6c6da h1:xRmpO92tb8y+Z85iUOMOicpCfaYcv7o3Cg3wKrIpg8g=
 github.com/google/pprof v0.0.0-20240711041743-f6c9dda6c6da/go.mod h1:K1liHPHnj73Fdn/EKuT8nrFqBihUSKXoLYU0BuatOYo=
 github.com/google/s2a-go v0.1.8 h1:zZDs9gcbt9ZPLV0ndSyQk6Kacx2g/X+SKYovpnz3SMM=
@@ -145,6 +151,7 @@ github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc h1:GN2Lv3MGO7AS6PrR
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
+github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -210,6 +217,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmd
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/profile v1.7.0 h1:hnbDkaNWPCLMO9wGLdBFTIZvzDrDfBM2072E1S9gJkA=
+github.com/pkg/profile v1.7.0/go.mod h1:8Uer0jas47ZQMJ7VD+OHknK4YDY07LPUC6dEvqDjvNo=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -330,6 +339,7 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/rest/helpers.go
+++ b/pkg/rest/helpers.go
@@ -112,3 +112,8 @@ func Normalize(v any) any {
 	}
 	return v
 }
+
+// NewGraph returns a new rest.Graph corresponding to the internal graph.Graph.
+func NewGraph(g *graph.Graph) *Graph {
+	return &Graph{Nodes: nodes(g), Edges: edges(g, &Options{})}
+}

--- a/pkg/rest/operations.go
+++ b/pkg/rest/operations.go
@@ -50,11 +50,12 @@ var BasePath = docs.SwaggerInfo.BasePath
 type API struct {
 	Engine  *engine.Engine
 	Configs config.Configs
+	Router  *gin.Engine
 }
 
 // New API instance, registers  handlers with a gin Engine.
 func New(e *engine.Engine, c config.Configs, r *gin.Engine) (*API, error) {
-	a := &API{Engine: e, Configs: c}
+	a := &API{Engine: e, Configs: c, Router: r}
 	r.Use(a.logger)
 	r.Use(a.context)
 	r.GET("/", func(c *gin.Context) { c.Redirect(http.StatusTemporaryRedirect, "/swagger/index.html") })

--- a/pkg/rest/profile.go
+++ b/pkg/rest/profile.go
@@ -1,0 +1,17 @@
+// Copyright: This file is part of korrel8r, released under https://github.com/korrel8r/korrel8r/blob/main/LICENSE
+
+package rest
+
+import (
+	"sync"
+
+	"github.com/gin-contrib/pprof"
+	"github.com/gin-gonic/gin"
+)
+
+var profileOnce sync.Once
+
+// WebProfile enables profiling REST endpoints.
+func WebProfile(router *gin.Engine) {
+	profileOnce.Do(func() { pprof.Register(router) })
+}


### PR DESCRIPTION
To help profile performance of korrel8r, added commands to run goal/neighbour searches
directly from command line, and flags to enable Go profiling.

- New commands: neighbours, goals.
- Flags: --profile and --profilePath enable profiling.
- NOTE: --profile=http enables HTTP profile server at Korrel8r endpoint.