### PR TITLE
chore: Disable test cache for 'make test'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,11 +72,11 @@ lint: $(GEN_SRC) $(GOLANGCI_LINT) $(SHFMT) $(SHELLCHECK) ## Run the linter to fi
 	$(SHELLCHECK) -x -S style hack/*.sh
 
 .PHONY: test
-test: $(GEN_SRC)		## Run all tests, requires an openshift cluster.
-	go test -fullpath -race ./...
+test: $(GEN_SRC)		## Run all tests, no cache. Requires an openshift cluster.
+	go test -count=1 -fullpath -race ./...
 
 test-no-cluster: $(GEN_SRC)	## Run all tests that don't require an openshift cluster.
-	go test -fullpath -race -skip '.*/Openshift' ./...
+	go test -count=1 -fullpath -race -skip '.*/Openshift' ./...
 
 cover:  $(GOCOVERDIR) ## Run tests with accumulated coverage stats in _cover.
 	@echo == Individual package test coverage.


### PR DESCRIPTION
Disabled to avoid hiding sproadic test failures.
Use 'go test ...' directly to get cached tests.