### PR TITLE
feat: incidents domain

### DIFF
--- a/cmd/korrel8r/cli_test.go
+++ b/cmd/korrel8r/cli_test.go
@@ -23,6 +23,7 @@ func TestMain_list(t *testing.T) {
 	require.NoError(t, test.ExecError(err))
 	want := `
 alert
+incident
 k8s
 log
 metric

--- a/cmd/korrel8r/main.go
+++ b/cmd/korrel8r/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/korrel8r/korrel8r/internal/pkg/test/mock"
 	"github.com/korrel8r/korrel8r/pkg/config"
 	"github.com/korrel8r/korrel8r/pkg/domains/alert"
+	"github.com/korrel8r/korrel8r/pkg/domains/incident"
 	"github.com/korrel8r/korrel8r/pkg/domains/k8s"
 	logdomain "github.com/korrel8r/korrel8r/pkg/domains/log"
 	"github.com/korrel8r/korrel8r/pkg/domains/metric"
@@ -100,7 +101,7 @@ func newEngine() (*engine.Engine, config.Configs) {
 	}
 	c := must.Must1(config.Load(*configFlag))
 	e := must.Must1(engine.Build().
-		Domains(k8s.Domain, logdomain.Domain, netflow.Domain, trace.Domain, alert.Domain, metric.Domain, mock.Domain("mock")).
+		Domains(k8s.Domain, logdomain.Domain, netflow.Domain, trace.Domain, alert.Domain, metric.Domain, incident.Domain, mock.Domain("mock")).
 		Config(c).
 		Engine())
 	return e, c

--- a/cmd/korrel8r/web_test.go
+++ b/cmd/korrel8r/web_test.go
@@ -82,6 +82,7 @@ func TestMain_server_insecure(t *testing.T) {
 	u := startServer(t, http.DefaultClient, "http", "-c", "testdata/korrel8r.yaml").String() + "/domains"
 	assertDo(t, http.DefaultClient, `[
 {"name":"alert"},
+{"name":"incident"},
 {"name":"k8s"},
 {"name":"log"},
 {"name":"metric"},
@@ -97,6 +98,7 @@ func TestMain_server_secure(t *testing.T) {
 	u := startServer(t, h, "https", "--cert", filepath.Join(tmpDir, "tls.crt"), "--key", filepath.Join(tmpDir, "tls.key"), "-c", "testdata/korrel8r.yaml").String() + "/domains"
 	assertDo(t, h, `[
 {"name":"alert"},
+{"name":"incident"},
 {"name":"k8s"},
 {"name":"log"},
 {"name":"metric"},

--- a/etc/korrel8r/openshift-route.yaml
+++ b/etc/korrel8r/openshift-route.yaml
@@ -13,6 +13,9 @@ stores:
     lokiStack: 'https://{{(query "k8s:Route:{namespace: netobserv, name: loki}" | first).Spec.Host}}'
   - domain: trace
     tempoStack: 'https://{{(query "k8s:Route:{namespace: openshift-tracing, name: tempo-platform-gateway}" | first).Spec.Host}}/api/traces/v1/platform/tempo/api/search'
+  - domain: incident
+    metrics: 'https://{{(query "k8s:Route:{namespace: openshift-monitoring, name: thanos-querier}" | first).Spec.Host}}'
+
 
 include:
   - rules/all.yaml

--- a/etc/korrel8r/openshift-svc.yaml
+++ b/etc/korrel8r/openshift-svc.yaml
@@ -18,5 +18,7 @@ stores:
   - domain: trace
     tempoStack: https://tempo-platform-gateway.openshift-tempo-operator.svc.cluster.local:8080/api/traces/v1/platform/tempo/api/search
     certificateAuthority: ./run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+  - domain: incident
+    metrics: https://thanos-querier.openshift-monitoring.svc:9091
 include:
   - rules/all.yaml

--- a/etc/korrel8r/rules/all.yaml
+++ b/etc/korrel8r/rules/all.yaml
@@ -5,3 +5,4 @@ include:
   - netflow.yaml
   - trace.yaml
   - openshift.yaml
+  - incident.yaml

--- a/etc/korrel8r/rules/incident.yaml
+++ b/etc/korrel8r/rules/incident.yaml
@@ -1,0 +1,18 @@
+rules:
+  - name: AlertToIncident
+    start:
+      domain: alert
+    goal:
+      domain: incident
+    result:
+      query: |-
+        incident:incident:{"alertLabels":
+          {{- with .Labels }}{{ mustToJson . -}}{{- end }}}
+  - name: IncidentToAlert
+    start:
+      domain: incident
+    goal:
+      domain: alert
+    result:
+      query: |-
+        alert:alert:{{- with .AlertsLabels }}{{ mustToJson . -}}{{- end }}}

--- a/etc/korrel8r/rules/incident_test.go
+++ b/etc/korrel8r/rules/incident_test.go
@@ -1,0 +1,36 @@
+// Copyright: This file is part of korrel8r, released under https://github.com/korrel8r/korrel8r/blob/main/LICENSE
+
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/korrel8r/korrel8r/pkg/domains/alert"
+	"github.com/korrel8r/korrel8r/pkg/domains/incident"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAlertToIncident(t *testing.T) {
+	e := setup()
+	t.Run("AlertToIncident", func(t *testing.T) {
+		tested("AlertToIncident")
+		got, err := e.Rule("AlertToIncident").Apply(
+			&alert.Object{Labels: map[string]string{"namespace": "foo", "deployment": "bar"}})
+		assert.NoError(t, err)
+		assert.Equal(t, `incident:incident:{"alertLabels":{"deployment":"bar","namespace":"foo"}}`, got.String())
+	})
+}
+
+func TestIncidentToAlert(t *testing.T) {
+	e := setup()
+	t.Run("IncidentToAlert", func(t *testing.T) {
+		tested("IncidentToAlert")
+		got, err := e.Rule("IncidentToAlert").Apply(
+			&incident.Object{Id: "incident-id", AlertsLabels: []map[string]string{
+				{"namespace": "foo", "deployment": "bar"},
+				{"namespace": "foobaz", "deployment": "barbaz"},
+			}})
+		assert.NoError(t, err)
+		assert.Equal(t, `alert:alert:[{"deployment":"bar","namespace":"foo"},{"deployment":"barbaz","namespace":"foobaz"}]}`, got.String())
+	})
+}

--- a/etc/korrel8r/rules/k8s_test.go
+++ b/etc/korrel8r/rules/k8s_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/korrel8r/korrel8r/pkg/domains/log"
 	"github.com/korrel8r/korrel8r/pkg/domains/metric"
 	"github.com/korrel8r/korrel8r/pkg/korrel8r"
+	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -95,6 +96,8 @@ func TestK8sAllToMetric(t *testing.T) {
 func TestK8sPOdToAlert(t *testing.T) {
 	e := setup()
 	pod := k8s.New[corev1.Pod]("aNamespace", "foo")
-	want := alert.Query{"namespace": "aNamespace", "pod": "foo"}
+	want, err := alert.Domain.Query(`alert:alert:{"namespace": "aNamespace","pod": "foo"}`)
+	assert.NoError(t, err)
+
 	testTraverse(t, e, k8s.ClassOf(pod), want.Class(), []korrel8r.Object{pod}, want)
 }

--- a/etc/korrel8r/rules/rules_test.go
+++ b/etc/korrel8r/rules/rules_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/korrel8r/korrel8r/pkg/config"
 	"github.com/korrel8r/korrel8r/pkg/domains/alert"
+	"github.com/korrel8r/korrel8r/pkg/domains/incident"
 	"github.com/korrel8r/korrel8r/pkg/domains/k8s"
 	"github.com/korrel8r/korrel8r/pkg/domains/log"
 	"github.com/korrel8r/korrel8r/pkg/domains/metric"
@@ -45,7 +46,7 @@ func setup() *engine.Engine {
 		panic(err)
 	}
 	e, err := engine.Build().
-		Domains(k8s.Domain, log.Domain, netflow.Domain, trace.Domain, alert.Domain, metric.Domain).
+		Domains(k8s.Domain, log.Domain, netflow.Domain, trace.Domain, alert.Domain, metric.Domain, incident.Domain).
 		Config(configs).
 		Stores(s).Engine()
 	if err != nil {

--- a/internal/pkg/test/domain/fixture.go
+++ b/internal/pkg/test/domain/fixture.go
@@ -13,6 +13,7 @@ import (
 	"github.com/korrel8r/korrel8r/internal/pkg/test"
 	"github.com/korrel8r/korrel8r/pkg/config"
 	"github.com/korrel8r/korrel8r/pkg/domains/alert"
+	"github.com/korrel8r/korrel8r/pkg/domains/incident"
 	"github.com/korrel8r/korrel8r/pkg/domains/k8s"
 	"github.com/korrel8r/korrel8r/pkg/domains/log"
 	"github.com/korrel8r/korrel8r/pkg/domains/metric"
@@ -63,7 +64,7 @@ func (f *Fixture) ClusterEngine(t testing.TB) *engine.Engine {
 	require.NoError(t, err)
 	config := filepath.Join(strings.TrimSpace(string(out)), "etc", "korrel8r", "openshift-route.yaml")
 	e, err := engine.Build().
-		Domains(k8s.Domain, log.Domain, netflow.Domain, trace.Domain, alert.Domain, metric.Domain).
+		Domains(k8s.Domain, log.Domain, netflow.Domain, trace.Domain, alert.Domain, metric.Domain, incident.Domain).
 		ConfigFile(config).
 		Engine()
 	require.NoError(t, err)

--- a/pkg/domains/incident/incident.go
+++ b/pkg/domains/incident/incident.go
@@ -1,0 +1,301 @@
+// Copyright: This file is part of korrel8r, released under https://github.com/korrel8r/korrel8r/blob/main/LICENSE
+
+// Package incident provides mapping to https://github.com/openshift/cluster-health-analyzer
+// incidents.
+//
+// # Class
+//
+// There is a single class `incident:incident`.
+//
+// # Object
+//
+// An incident object contains id and mapping to the sources (alert is the only
+// supported source type at the moment).
+//
+// # Query
+//
+// One can query the incident by its id.
+//
+//	incident:incident:{"id":"id-of-the-incident"}
+//
+// It's also possible to provide labels from
+// an alert to get a corresponding incident.
+//
+//	incident:incident:{"alertLabels":{
+//	 "alertname":"AlertmanagerReceiversNotConfigured",
+//	 "namespace":"openshift-monitoring"}}
+//
+// # Store
+//
+// A client of Prometheus. Store configuration:
+//
+//	domain: incident
+//	metrics: PROMETHEUS_URL
+package incident
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/api"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+
+	"github.com/korrel8r/korrel8r/internal/pkg/logging"
+	"github.com/korrel8r/korrel8r/pkg/config"
+	"github.com/korrel8r/korrel8r/pkg/domains/k8s"
+	"github.com/korrel8r/korrel8r/pkg/korrel8r"
+	"github.com/korrel8r/korrel8r/pkg/korrel8r/impl"
+)
+
+var (
+	_ korrel8r.Domain = Domain
+	_ korrel8r.Class  = Class{}
+	_ korrel8r.Query  = Query{}
+	_ korrel8r.Store  = &Store{}
+	_ korrel8r.Object = &Object{}
+
+	log = logging.Log()
+)
+
+var Domain = domain{}
+
+type domain struct{}
+
+const (
+	name        = "incident"
+	description = "Incidents group alerts into higher-level groups."
+
+	srcLabelPrefix = "src_"
+)
+
+func (domain) Name() string                { return name }
+func (d domain) String() string            { return d.Name() }
+func (domain) Description() string         { return description }
+func (domain) Class(string) korrel8r.Class { return Class{} }
+func (domain) Classes() []korrel8r.Class   { return []korrel8r.Class{Class{}} }
+func (d domain) Query(s string) (korrel8r.Query, error) {
+	_, query, err := impl.UnmarshalQueryString[Query](d, s)
+	return query, err
+}
+
+const (
+	StoreKeyMetrics = "metrics"
+)
+
+func (domain) Store(s any) (korrel8r.Store, error) {
+	cs, err := impl.TypeAssert[config.Store](s)
+	if err != nil {
+		return nil, err
+	}
+	metrics := cs[StoreKeyMetrics]
+	metricsURL, err := url.Parse(metrics)
+	if err != nil {
+		return nil, err
+	}
+	hc, err := k8s.NewHTTPClient(cs)
+	if err != nil {
+		return nil, err
+	}
+	return NewStore(metricsURL, hc)
+}
+
+// Class represents any Incident. There is only a single class, named "incident".
+type Class struct{}
+
+func (c Class) Domain() korrel8r.Domain { return Domain }
+func (c Class) Name() string            { return name }
+func (c Class) String() string          { return impl.ClassString(c) }
+func (c Class) Description() string {
+	return description
+}
+func (c Class) Unmarshal(b []byte) (korrel8r.Object, error) { return impl.UnmarshalAs[*Object](b) }
+func (c Class) ID(o korrel8r.Object) any {
+	if o, ok := o.(*Object); ok {
+		return o.Id
+	}
+	return nil
+}
+
+func (c Class) Preview(o korrel8r.Object) string {
+	if o, ok := o.(*Object); ok {
+		return o.Id
+	}
+	return ""
+}
+
+// Object contains incident data, passed as *Object when used as a korrel8r.Object.
+type Object struct {
+	// Common fields.
+	Id           string              `json:"id"`
+	AlertsLabels []map[string]string `json:"alertsLabels"`
+
+	// Prometheus fields.
+	Value string `json:"value"`
+}
+
+type Query struct {
+	Id string `json:"id,omitempty"`
+	// Alert labels to match against
+	AlertLabels map[string]string `json:"alertLabels,omitempty"`
+}
+
+func (q Query) Class() korrel8r.Class { return Class{} }
+func (q Query) Data() string          { b, _ := json.Marshal(q); return string(b) }
+func (q Query) String() string        { return impl.QueryString(q) }
+
+// Store is a client of Prometheus.
+type Store struct {
+	prometheusAPI v1.API
+}
+
+// NewStore creates a new store client for a Prometheus URL.
+func NewStore(prometheusURL *url.URL, hc *http.Client) (korrel8r.Store, error) {
+	prometheusAPI, err := newPrometheusClient(prometheusURL, hc)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Store{
+		prometheusAPI: prometheusAPI,
+	}, nil
+}
+
+func newPrometheusClient(u *url.URL, hc *http.Client) (v1.API, error) {
+	client, err := api.NewClient(api.Config{
+		Address: u.String(),
+		Client:  hc,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return v1.NewAPI(client), nil
+}
+
+func (Store) Domain() korrel8r.Domain { return Domain }
+
+func (s Store) Get(ctx context.Context, query korrel8r.Query, c *korrel8r.Constraint, result korrel8r.Appender) error {
+	q, err := impl.TypeAssert[Query](query)
+	if err != nil {
+		return err
+	}
+
+	promq, t, err := preparePromQL(q, c)
+	if err != nil {
+		return err
+	}
+
+	log.V(3).Info("Loading the incidents", "query", promq)
+
+	resp, _, err := s.prometheusAPI.Query(ctx, promq, t)
+	if err != nil {
+		return fmt.Errorf("Failed to query incidents from Prometheus API: %w", err)
+	}
+
+	data := resp.(model.Vector)
+	log.V(3).Info("Incidents data loaded", "count", len(data))
+
+	incidents := loadObjects(data)
+	log.V(3).Info("Incidents loaded", "count", len(incidents))
+
+	incidents = filterObjects(incidents, q)
+	log.V(2).Info("Incidents filtered", "count", len(incidents))
+
+	for _, i := range incidents {
+		result.Append(i)
+	}
+
+	return nil
+}
+
+func preparePromQL(q Query, c *korrel8r.Constraint) (string, time.Time, error) {
+	t := time.Now().UTC()
+	promq := "cluster:health:components:map"
+
+	if q.Id != "" {
+		promq += fmt.Sprintf(`{group_id="%s"}`, q.Id)
+	}
+
+	if c != nil {
+		if c.End != nil {
+			t = *c.End
+		}
+
+		if c.Start != nil {
+			duration := int(t.Sub(*c.Start).Seconds())
+			if duration < 0 {
+				return "", time.Time{}, fmt.Errorf("Start constraint is happening before the end time.")
+			}
+			promq = fmt.Sprintf("max_over_time(%s[%ds])", promq, duration)
+		}
+	}
+	return promq, t, nil
+}
+
+func loadObjects(data model.Vector) []*Object {
+	var incidents = make(map[string]*Object)
+	for _, s := range data {
+		labels := make(map[string]string)
+		for k, v := range s.Metric {
+			labels[string(k)] = string(v)
+		}
+
+		id := labels["group_id"]
+
+		i, found := incidents[id]
+		if !found {
+			i = &Object{Id: id}
+			incidents[id] = i
+		}
+
+		srcLabels := make(map[string]string)
+		for k, v := range labels {
+			if strings.HasPrefix(k, srcLabelPrefix) {
+				srcLabels[k[len(srcLabelPrefix):]] = v
+			}
+		}
+		if labels["type"] == "alert" {
+			i.AlertsLabels = append(i.AlertsLabels, srcLabels)
+		}
+	}
+
+	ret := make([]*Object, 0, len(incidents))
+	for _, i := range incidents {
+		ret = append(ret, i)
+	}
+	return ret
+}
+
+func filterObjects(objects []*Object, q Query) (ret []*Object) {
+	for _, o := range objects {
+		if len(q.AlertLabels) > 0 {
+			// Check for any source labels matching the labels in the query.
+			for _, l := range o.AlertsLabels {
+				if isSubsetOf(l, q.AlertLabels) {
+					log.V(3).Info("Incident matched alerts filter", "incident_id", o.Id)
+					ret = append(ret, o)
+					break
+				}
+			}
+		} else {
+			// No AlertLabels provided: no futher filtering needed.
+			ret = append(ret, o)
+		}
+	}
+	return ret
+}
+
+func isSubsetOf(part, whole map[string]string) bool {
+	for k, v := range part {
+		if whole[k] != v {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/domains/incident/incident_domain_test.go
+++ b/pkg/domains/incident/incident_domain_test.go
@@ -1,16 +1,15 @@
 // Copyright: This file is part of korrel8r, released under https://github.com/korrel8r/korrel8r/blob/main/LICENSE
 
-package alert_test
+package incident_test
 
 import (
 	"testing"
 
 	"github.com/korrel8r/korrel8r/internal/pkg/test/domain"
-	"github.com/korrel8r/korrel8r/pkg/domains/alert"
+	"github.com/korrel8r/korrel8r/pkg/domains/incident"
 )
 
-// TODO https://github.com/korrel8r/korrel8r/issues/148  store does not respect limits. Remove SkipCluster when fixed.
-var fixture = domain.Fixture{Query: alert.Query{Qs: "{}"}, SkipCluster: true}
+var fixture = domain.Fixture{Query: incident.Query{}, SkipCluster: true}
 
 func TestAlertDomain(t *testing.T)      { fixture.Test(t) }
 func BenchmarkAlertDomain(b *testing.B) { fixture.Benchmark(b) }

--- a/pkg/domains/incident/testdata/domain_test.yaml
+++ b/pkg/domains/incident/testdata/domain_test.yaml
@@ -1,0 +1,11 @@
+'incident:incident:{}':
+  - {"id":"1ac576a8-5b47-4363-b9b1-2163dbd7335f","alertsLabels":[{"alertname":"alert-1"}]}
+  - {"id":"dcefbddf-7cb6-4744-b85f-745d3479a4cd","alertsLabels":[{"alertname":"alert-2"}]}
+  - {"id":"e5e91faf-e159-4616-bca6-82e9546d4296","alertsLabels":[{"alertname":"alert-3"}]}
+  - {"id":"53cff7c2-d42b-4a1a-ae58-960948d45cf5","alertsLabels":[{"alertname":"alert-4"}]}
+  - {"id":"08119961-4648-42c1-bba0-28b21aa4c88f","alertsLabels":[{"alertname":"alert-5"}]}
+  - {"id":"2deb32d3-c2dc-4177-9de2-a87f18597d60","alertsLabels":[{"alertname":"alert-6"}]}
+  - {"id":"1c8a108b-caf6-4090-aced-d00606eeceb3","alertsLabels":[{"alertname":"alert-7"}]}
+  - {"id":"e78d004e-3405-45bb-813a-45a4834d0cab","alertsLabels":[{"alertname":"alert-8"}]}
+  - {"id":"914f1e3a-d39e-49e0-8ec6-1bcd642c44ed","alertsLabels":[{"alertname":"alert-9"}]}
+  - {"id":"63910992-ab91-4d0e-bc80-2aefbf4bbea1","alertsLabels":[{"alertname":"alert-10"}]}


### PR DESCRIPTION
This patch provides support for bidirection mapping between alerts and incidents, as provided by https://github.com/openshift/cluster-health-analyzer.

Apart from the incident domain implementation itself, I needed to expand the alert domain query to support passing list of maps, to be able to match multiple alerts, so that I could query all related alerts in the `IncidentToAlerts` rule.