### PR TITLE
fix(#236): Better error logging for missing stores.

### DIFF
--- a/cmd/korrel8r/get.go
+++ b/cmd/korrel8r/get.go
@@ -67,7 +67,7 @@ func init() {
 }
 
 func check(err error) {
-	if traverse.IsPartialError(err) {
+	if korrel8r.IsPartialError(err) {
 		fmt.Fprintln(os.Stderr, err)
 	} else {
 		must.Must(err)
@@ -106,7 +106,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			e, _ := newEngine()
 			var goals []korrel8r.Class
-			for _, g := range args[1:] {
+			for _, g := range args {
 				goals = append(goals, must.Must1(e.Class(g)))
 			}
 			ctx, cancel := korrel8r.WithConstraint(context.Background(), constraint())

--- a/cmd/korrel8r/main.go
+++ b/cmd/korrel8r/main.go
@@ -92,5 +92,6 @@ func newEngine() (*engine.Engine, config.Configs) {
 		Domains(append(domains.All, mock.NewDomain("mock"))...).
 		Config(c).
 		Engine())
+	log.V(2).Info("Configuration loaded", "source", *configFlag)
 	return e, c
 }

--- a/etc/korrel8r/rules/rules_test.go
+++ b/etc/korrel8r/rules/rules_test.go
@@ -34,8 +34,8 @@ func setup() *engine.Engine {
 	if err != nil {
 		panic(err)
 	}
-	for _, c := range configs {
-		c.Stores = nil // Use fake stores, not configured defaults.
+	for i := range configs {
+		configs[i].Stores = nil // Use fake stores, not configured defaults.
 	}
 	c := fake.NewClientBuilder().WithRESTMapper(testrestmapper.TestOnlyStaticRESTMapper(scheme.Scheme)).Build()
 	s, err := k8s.NewStoreWithDiscovery(c, &rest.Config{}, &fakeDiscovery{})
@@ -44,7 +44,7 @@ func setup() *engine.Engine {
 	}
 	e, err := engine.Build().
 		Domains(domains.All...).
-		Stores(s). // NOTE: k8s store must come before configs, some templates use k8s functions.
+		Stores(s).
 		Config(configs).
 		Engine()
 	if err != nil {

--- a/pkg/config/configs.go
+++ b/pkg/config/configs.go
@@ -14,12 +14,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/korrel8r/korrel8r/internal/pkg/logging"
 	"github.com/korrel8r/korrel8r/pkg/unique"
 	"sigs.k8s.io/yaml"
 )
-
-var log = logging.Log()
 
 // Load loads all configurations from a file or URL.
 //
@@ -90,7 +87,6 @@ func (l *loader) load(source string) error {
 		return nil // Already loaded
 	}
 	l.loaded.Add(source)
-	log.V(2).Info("Configuration: Loading", "config", source)
 	b, err := readFileOrURL(source)
 	if err != nil {
 		return fmt.Errorf("%v: %w", source, err)

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -98,5 +98,5 @@ type Class struct {
 type Tuning struct {
 	// RequestTimeout cancel requests if they last longer than this timeout.
 	// Cancelling a correlation operation may return an error or a partial result (HTTP 206).
-	RequestTimeout Duration `json:"requestTimeout,omitempty"`
+	RequestTimeout Duration `json:"requestTimeout"`
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -159,8 +159,8 @@ func (e *Engine) Get(ctx context.Context, query korrel8r.Query, constraint *korr
 		defer cancel()
 	}
 	ss := e.stores[query.Class().Domain()]
-	if ss == nil {
-		return fmt.Errorf("no stores found for domain %v", query.Class().Domain())
+	if len(ss.stores) == 0 {
+		return fmt.Errorf("no stores found for domain %v", query.Class().Domain().Name())
 	}
 	return ss.Get(ctx, query, constraint, result)
 }

--- a/pkg/engine/traverse/async.go
+++ b/pkg/engine/traverse/async.go
@@ -176,7 +176,7 @@ func (n *node) Run(ctx context.Context) {
 		}
 		before := len(n.Result.List())
 		err := n.engine.Get(ctx, q, korrel8r.ConstraintFrom(ctx), n.Result)
-		n.errs.Log(err, "Get failed", "error", err, "query", q)
+		n.errs.Log(err, "Get failed", "query", q)
 		result := n.Result.List()[before:]
 		for _, o := range result {
 			n.applyRules(ctx, o)
@@ -210,7 +210,7 @@ func (n *node) applyRules(ctx context.Context, o korrel8r.Object) {
 				n.errs.Log(qe.err, "Rule did not apply", "rule", l.Rule.Name())
 				return
 			}
-			log.V(4).Info("Applied", "rule", l.Rule.Name(), "query", qe.q)
+			log.V(4).Info("Create query", "rule", l.Rule.Name(), "query", qe.q)
 		}
 		if qe.q.Class() != l.Goal().Class { // Wrong line, save for later
 			applied[l.Rule] = qe

--- a/pkg/engine/traverse/errors.go
+++ b/pkg/engine/traverse/errors.go
@@ -3,7 +3,6 @@
 package traverse
 
 import (
-	"errors"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -44,26 +43,8 @@ func (e *Errors) Err() error {
 	case e.errs.Err() == nil:
 		return nil
 	case e.ok > 0:
-		return &PartialError{e.errs.Err()}
+		return &korrel8r.PartialError{Err: e.errs.Err()}
 	default:
 		return e.errs.Err()
 	}
-}
-
-// PartialError indicates some errors were encountered but there are still some results.
-type PartialError struct{ Err error }
-
-func (e *PartialError) Error() string {
-	return errors.Join(errors.New("results may be incomplete, there were errors"), e.Err).Error()
-}
-
-var _ error = &PartialError{}
-
-func IsPartialError(err error) bool { return korrel8r.IsErrorType[*PartialError](err) }
-
-func IgnorePartialError(err error) error {
-	if IsPartialError(err) {
-		return nil
-	}
-	return err
 }

--- a/pkg/engine/traverse/traverse_test.go
+++ b/pkg/engine/traverse/traverse_test.go
@@ -167,7 +167,7 @@ func TestPartialError(t *testing.T) {
 	require.NoError(t, err)
 	start := Start{Class: ca, Objects: []korrel8r.Object{0}}
 	g, err := New(e, e.Graph()).Neighbours(context.Background(), start, 3)
-	var pe *PartialError
+	var pe *korrel8r.PartialError
 	assert.ErrorContains(t, err, "no good")
 	assert.ErrorAs(t, err, &pe)
 	assert.ElementsMatch(t, g.NodesFor(ca, cb, cc), graph.NodesOf(g.Nodes()))
@@ -186,9 +186,9 @@ func TestErrors(t *testing.T) {
 	assert.EqualError(t, errs.Err(), "bad\nworse", "")
 	errs.Log(errors.New("bad"), "") // Don't repeat
 	assert.EqualError(t, errs.Err(), "bad\nworse", "")
-	assert.False(t, IsPartialError(errs.Err()))
+	assert.False(t, korrel8r.IsPartialError(errs.Err()))
 	errs.Log(nil, "") // Partial success
-	assert.True(t, IsPartialError(errs.Err()))
+	assert.True(t, korrel8r.IsPartialError(errs.Err()))
 	assert.ErrorContains(t, errs.Err(), "bad\nworse")
 }
 

--- a/pkg/korrel8r/errors.go
+++ b/pkg/korrel8r/errors.go
@@ -27,3 +27,21 @@ func IsErrorType[T error](err error) bool {
 	var target T
 	return errors.As(err, &target)
 }
+
+// PartialError indicates some errors were encountered but there are still some results.
+type PartialError struct{ Err error }
+
+func (e *PartialError) Error() string {
+	return errors.Join(errors.New("results may be incomplete, there were errors"), e.Err).Error()
+}
+
+var _ error = &PartialError{}
+
+func IsPartialError(err error) bool { return IsErrorType[*PartialError](err) }
+
+func IgnorePartialError(err error) error {
+	if IsPartialError(err) {
+		return nil
+	}
+	return err
+}

--- a/pkg/rest/operations.go
+++ b/pkg/rest/operations.go
@@ -156,13 +156,13 @@ func check(c *gin.Context, code int, err error, format ...any) (ok bool) {
 		return false
 	case err == nil:
 		return true
-	case traverse.IsPartialError(err):
+	case korrel8r.IsPartialError(err):
 		_ = c.Error(err) // Save the error for interrupted()
 		return true      // Allow the handler to succeed
 	default:
 		ginErr := c.Error(err)
 		c.AbortWithStatusJSON(code, ginErr.JSON())
-		log.Error(err, "Request failed", "url", c.Request.URL, "code", code, "error", err)
+		log.V(1).Info("Request failed", "url", c.Request.URL, "code", code, "error", err)
 		return false
 	}
 }
@@ -189,7 +189,7 @@ func (a *API) context(c *gin.Context) {
 // Interrupted checks for a context error or partial error,
 // indicating we may have a partial result.
 func interrupted(c *gin.Context) bool {
-	return c.Errors.Last() != nil && traverse.IsPartialError(c.Errors.Last()) ||
+	return c.Errors.Last() != nil && korrel8r.IsPartialError(c.Errors.Last()) ||
 		c.Request.Context().Err() == context.DeadlineExceeded
 }
 


### PR DESCRIPTION
- Initial failure to connect is logged as a warning.
- Identical errors from the same store are only logged once.