### PR TITLE
fix(#263) Allow rules to handle cluster-scoped objects correctly

### DIFF
--- a/etc/korrel8r/rules/k8s.yaml
+++ b/etc/korrel8r/rules/k8s.yaml
@@ -132,7 +132,10 @@ rules:
        query: |-
          {{- with index .metadata "ownerReferences"}}
            {{- with first . -}}
-             {{k8sClass .apiVersion .kind}}:{"namespace":"{{$.metadata.namespace}}","name":"{{.name}}"}
+             {{$class := k8sClass .apiVersion .kind -}}
+             {{$class}}:{
+               {{- if k8sIsNamespaced $class}}"namespace":"{{$.metadata.namespace}}",{{- end -}}
+             "name":"{{.name}}"}
            {{- end}}
          {{end -}}
 
@@ -186,7 +189,7 @@ rules:
        classes: [PersistentVolume]
      goal:
        domain: k8s
-       classes: [StorageClass]
+       classes: [StorageClass.storage.k8s.io]
      result:
        query: |-
          k8s:StorageClass.storage.k8s.io:{"name":"{{.spec.storageClassName}}"}
@@ -197,7 +200,7 @@ rules:
        classes: [PersistentVolumeClaim]
      goal:
        domain: k8s
-       classes: [StorageClass]
+       classes: [StorageClass.storage.k8s.io]
      result:
        query: |-
          k8s:StorageClass.storage.k8s.io:{"name":"{{.spec.storageClassName}}"}

--- a/etc/korrel8r/rules/k8s_test.go
+++ b/etc/korrel8r/rules/k8s_test.go
@@ -67,11 +67,23 @@ func TestK8sRules(t *testing.T) {
 				"metadata": k8s.Object{
 					"ownerReferences": []k8s.Object{{
 						"name":       "owner",
-						"kind":       "Deployment",
+						"kind":       "Deployment", // Namespace scoped owner
 						"apiVersion": "apps/v1",
 					}}},
 			}),
 			query: `k8s:Deployment.v1.apps:{"namespace":"aNamespace","name":"owner"}`,
+		},
+		{
+			rule: "DependentToOwner",
+			start: newK8s("Pod", "aNamespace", "foo", k8s.Object{
+				"metadata": k8s.Object{
+					"ownerReferences": []k8s.Object{{
+						"name":       "owner",
+						"kind":       "PersistentVolume", // Cluster scoped owner
+						"apiVersion": "v1",
+					}}},
+			}),
+			query: `k8s:PersistentVolume.v1:{"name":"owner"}`,
 		},
 		{
 			rule: "VmiToNode",

--- a/etc/korrel8r/rules/rules_test.go
+++ b/etc/korrel8r/rules/rules_test.go
@@ -22,10 +22,11 @@ import (
 	"github.com/korrel8r/korrel8r/pkg/unique"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/meta/testrestmapper"
+	"k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakediscovery "k8s.io/client-go/discovery/fake"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	clienttesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -37,8 +38,20 @@ func setup() *engine.Engine {
 	for i := range configs {
 		configs[i].Stores = nil // Use fake stores, not configured defaults.
 	}
-	c := fake.NewClientBuilder().WithRESTMapper(testrestmapper.TestOnlyStaticRESTMapper(scheme.Scheme)).Build()
-	s, err := k8s.NewStoreWithDiscovery(c, &rest.Config{}, &fakeDiscovery{})
+	c := fake.NewClientBuilder().
+		WithRESTMapper(testrestmapper.TestOnlyStaticRESTMapper(scheme.Scheme)).
+		Build()
+	// Create a fake discovery with custom resources needed by the test.
+	fd := &fakediscovery.FakeDiscovery{
+		Fake: &clienttesting.Fake{
+			Resources: []*metav1.APIResourceList{
+				{GroupVersion: "kubevirt.io", APIResources: []metav1.APIResource{
+					{Kind: "VirtualMachineInstance", Namespaced: true},
+				}},
+			},
+		},
+	}
+	s, err := k8s.Domain.NewStoreWithDiscovery(c, &rest.Config{}, fd)
 	if err != nil {
 		panic(err)
 	}
@@ -115,22 +128,4 @@ func k8sEvent(o k8s.Object, name string) k8s.Object {
 			"apiVersion": gvk.GroupVersion().String(),
 		}})
 	return e
-}
-
-// fake discovery using a Scheme
-type fakeDiscovery struct {
-	*fakediscovery.FakeDiscovery // Stubs to implement interface
-}
-
-func (f *fakeDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
-	var rl metav1.APIResourceList
-	for gvk := range scheme.Scheme.AllKnownTypes() {
-		r := metav1.APIResource{
-			Group:   gvk.Group,
-			Version: gvk.Version,
-			Kind:    gvk.Kind,
-		}
-		rl.APIResources = append(rl.APIResources, r)
-	}
-	return []*metav1.APIResourceList{&rl}, nil
 }

--- a/internal/pkg/test/mock/store.go
+++ b/internal/pkg/test/mock/store.go
@@ -95,9 +95,8 @@ func (s *Store) Get(ctx context.Context, q korrel8r.Query, constraint *korrel8r.
 	return nil
 }
 
-func (s *Store) Domain() korrel8r.Domain                 { return s.domain }
-func (s *Store) StoreClasses() ([]korrel8r.Class, error) { return s.classes.List(), nil }
-func (s *Store) Resolve(korrel8r.Query) *url.URL         { panic("not implemented") }
+func (s *Store) Domain() korrel8r.Domain         { return s.domain }
+func (s *Store) Resolve(korrel8r.Query) *url.URL { panic("not implemented") }
 
 func (s *Store) AddLookup(lookup QueryFunc) { s.lookup = append(s.lookup, lookup) }
 

--- a/internal/pkg/text/print.go
+++ b/internal/pkg/text/print.go
@@ -33,11 +33,7 @@ func (e *Printer) ListDomains(w io.Writer) {
 }
 
 func (p *Printer) ListClasses(w io.Writer, d korrel8r.Domain) {
-	classes, err := p.ClassesFor(d)
-	if err != nil {
-		p.Error(w, err)
-		return
-	}
+	classes := d.Classes()
 	for _, c := range classes {
 		fmt.Fprintln(w, c.Name())
 	}

--- a/pkg/domains/k8s/client.go
+++ b/pkg/domains/k8s/client.go
@@ -12,12 +12,12 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	klog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // SetLogger sets the logger for controller-runtime.
 func SetLogger(l logr.Logger) {
-	log.SetLogger(l)
+	klog.SetLogger(l)
 }
 
 // NewClient provides a general-purpose k8s client.

--- a/pkg/domains/k8s/template_funcs.go
+++ b/pkg/domains/k8s/template_funcs.go
@@ -14,11 +14,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// TemplateFuncs for this domain. See package description.
-func (domain) TemplateFuncs() map[string]any {
+// TemplateFuncs for this store. See description at top of file.
+func (d *domain) TemplateFuncs() map[string]any {
 	return map[string]any{
 		"k8sClass": func(apiVersion, kind string) korrel8r.Class {
 			return Class(schema.FromAPIVersionAndKind(apiVersion, kind))
+		},
+		"k8sIsNamespaced": func(c korrel8r.Class) bool {
+			kc, ok := c.(Class)
+			return ok && kc.IsNamespaced()
 		},
 	}
 }

--- a/pkg/domains/log/direct_store.go
+++ b/pkg/domains/log/direct_store.go
@@ -13,6 +13,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/korrel8r/korrel8r/internal/pkg/must"
 	"github.com/korrel8r/korrel8r/pkg/domains/k8s"
 	"github.com/korrel8r/korrel8r/pkg/korrel8r"
 	"github.com/korrel8r/korrel8r/pkg/korrel8r/impl"
@@ -23,7 +24,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-var podClass = k8s.ClassNamed("Pod.v1")
+var podClass = must.Must1(k8s.ParseClass("Pod.v1"))
 
 type directStore struct {
 	*impl.Store

--- a/pkg/domains/log/log.go
+++ b/pkg/domains/log/log.go
@@ -46,7 +46,7 @@ func (*domain) Store(s any) (korrel8r.Store, error) {
 	if err != nil {
 		return nil, err
 	}
-	ks, err := k8s.NewStore(nil, nil)
+	ks, err := k8s.Domain.NewStore(nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/engine/builder.go
+++ b/pkg/engine/builder.go
@@ -226,11 +226,6 @@ func (b *Builder) classes(r config.Rule, spec *config.ClassSpec) []korrel8r.Clas
 		}
 		return list.List
 	} else { // Wildcard
-		classes, err := b.e.ClassesFor(d)
-		if err != nil {
-			// Log a message but continue
-			log.Error(err, "Skip rule", "rule", r)
-		}
-		return classes
+		return d.Classes()
 	}
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -70,18 +70,6 @@ func (e *Engine) StoreConfigsFor(d korrel8r.Domain) []config.Store {
 	return nil
 }
 
-// ClassesFor collects classes from  the domain or its stores.
-func (e *Engine) ClassesFor(d korrel8r.Domain) ([]korrel8r.Class, error) {
-	classes := d.Classes()
-	if len(classes) > 0 {
-		return classes, nil
-	}
-	if s := e.StoreFor(d); s != nil {
-		return s.StoreClasses()
-	}
-	return nil, nil
-}
-
 // Class parses a full class name and returns the
 func (e *Engine) Class(fullname string) (korrel8r.Class, error) {
 	d, c := impl.ClassSplit(fullname)
@@ -116,15 +104,6 @@ func (e *Engine) DomainClass(domain, class string) (korrel8r.Class, error) {
 	c := d.Class(class)
 	if c == nil {
 		return nil, notFound()
-	}
-	if len(d.Classes()) == 0 { // Domain does not validate classes, check with store.
-		classes, err := e.ClassesFor(d)
-		if err != nil {
-			return nil, err
-		}
-		if len(classes) > 0 && slices.Index(classes, c) < 0 {
-			return nil, notFound() // Not valid according to store
-		}
 	}
 	return c, nil
 }

--- a/pkg/engine/stores.go
+++ b/pkg/engine/stores.go
@@ -88,14 +88,6 @@ func (s *storeHolder) Get(ctx context.Context, q korrel8r.Query, constraint *kor
 	return err
 }
 
-func (s *storeHolder) StoreClasses() ([]korrel8r.Class, error) {
-	if wrapped, err := s.Ensure(); err != nil {
-		return nil, err
-	} else {
-		return wrapped.StoreClasses()
-	}
-}
-
 // Ensure the store is connected.
 func (s *storeHolder) Ensure() (korrel8r.Store, error) {
 	s.lock.Lock()
@@ -176,19 +168,6 @@ func (ss *storeHolders) Get(ctx context.Context, q korrel8r.Query, constraint *k
 		return nil
 	}
 	return errs.Err()
-}
-
-// Classes returns the total set of classes for all the stores.
-// It may return a non-nil error and a non-nil partial list of classes.
-func (ss *storeHolders) StoreClasses() ([]korrel8r.Class, error) {
-	list := unique.NewList[korrel8r.Class]()
-	errs := &unique.Errors{}
-	for _, s := range ss.stores {
-		classes, err := s.StoreClasses()
-		errs.Add(err)
-		list.Append(classes...)
-	}
-	return list.List, errs.Err()
 }
 
 // Configs returns the expanded configurations for each store.

--- a/pkg/korrel8r/impl/store.go
+++ b/pkg/korrel8r/impl/store.go
@@ -23,8 +23,7 @@ type Store struct {
 
 func NewStore(d korrel8r.Domain) *Store { return &Store{d} }
 
-func (s *Store) Domain() korrel8r.Domain                 { return s.domain }
-func (s *Store) StoreClasses() ([]korrel8r.Class, error) { return s.domain.Classes(), nil }
+func (s *Store) Domain() korrel8r.Domain { return s.domain }
 
 // Get and decode a REST response, for stores that use raw HTTP clients.
 // body is decoded from the response, it must point to a JSON decodable type.

--- a/pkg/korrel8r/impl/store_test.go
+++ b/pkg/korrel8r/impl/store_test.go
@@ -24,7 +24,6 @@ func TestStore(t *testing.T) {
 	testDomainSingleton = d
 	s := testStore{NewStore(d)}
 	assert.Equal(t, d, s.Domain())
-	cs, err := s.StoreClasses()
-	assert.NoError(t, err)
+	cs := d.Classes()
 	assert.Equal(t, []korrel8r.Class{testClass("a"), testClass("b")}, cs)
 }

--- a/pkg/korrel8r/impl/try_stores.go
+++ b/pkg/korrel8r/impl/try_stores.go
@@ -15,8 +15,7 @@ var _ korrel8r.Store = TryStores{}
 // TryStores Get tries each store in turn. Uses the first store to satisfy other Store methods.
 type TryStores []korrel8r.Store
 
-func (ts TryStores) Domain() korrel8r.Domain                 { return ts[0].Domain() }
-func (ts TryStores) StoreClasses() ([]korrel8r.Class, error) { return ts[0].StoreClasses() }
+func (ts TryStores) Domain() korrel8r.Domain { return ts[0].Domain() }
 
 func (ts TryStores) Get(ctx context.Context, q korrel8r.Query, c *korrel8r.Constraint, a korrel8r.Appender) error {
 	var errs error

--- a/pkg/korrel8r/korrel8r.go
+++ b/pkg/korrel8r/korrel8r.go
@@ -87,8 +87,6 @@ type Store interface {
 	// If Constraint is non-nil, only objects satisfying the constraint are returned.
 	// Note: a "not found" condition should give an empty result, it should not be reported as an error.
 	Get(context.Context, Query, *Constraint, Appender) error
-	// StoreClasses gets the list of classes supported by the [Store]. See [Domain.Classes]
-	StoreClasses() ([]Class, error)
 }
 
 // Query is a request that selects some subset of Objects from a Store.


### PR DESCRIPTION
DependentToOwner is an example of a rule that needs to distinguish cluster and namespace scoped goal
types to generate correct queries (with or without a namespace).

To allow this, rule templates can now call `k8sIsNamespaced` determine if a goal class is namespaced.

Refactoring done as a result:
- Remove Store.StoreClasses(), the Domain interface is the only source for listing classes.
- k8s.Store uses the discovery client to add classes to the Domain
- Simplified store code by removing StoreClasses everywhere.