### PR TITLE
fix: lock-free session pool, other cleanup

### DIFF
--- a/cmd/korrel8r/web.go
+++ b/cmd/korrel8r/web.go
@@ -22,8 +22,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const maxDuration time.Duration = 1<<63 - 1
-
 var webCmd = &cobra.Command{
 	Use:   "web [flags]",
 	Short: "Start REST server. Listening address must be  provided via --http or --https.",
@@ -65,23 +63,29 @@ var webCmd = &cobra.Command{
 		}
 
 		configs := must.Must1(config.Load(*configFlag))
-		newEngine := func() (*engine.Engine, error) { return newEngineWithConfigs(configs) }
-		defaultEngine := must.Must1(newEngine()) // Default engine
-		var sessions session.Manager
-		switch {
-		case defaultEngine.Tuning.SessionTimeout == nil: // No timeout
-			sessions = session.NewPool(maxDuration, newEngine)
-		case defaultEngine.Tuning.SessionTimeout.Duration > 0:
-			sessions = session.NewPool(defaultEngine.Tuning.SessionTimeout.Duration, newEngine)
-		default: // Sessions are disabled, use a single session.
-			sessions = session.NewSingle(defaultEngine, configs)
+		newEngine := func() (*engine.Engine, config.Configs, error) {
+			e, err := newEngineWithConfigs(configs)
+			return e, configs, err
 		}
+
+		// Use session timeout from initial configuration.
+		var timeout time.Duration
+		if len(configs) > 0 && configs[0].Tuning != nil {
+			timeout = time.Duration(configs[0].Tuning.SessionTimeout)
+		}
+		sessions := session.NewPool(timeout, newEngine)
+
 		gin.SetMode(gin.ReleaseMode)
 		router := gin.New()
 		router.Use(gin.Recovery())
 		// Middleware to add authentication and timeout to the request context.
 		router.Use(func(c *gin.Context) {
-			ctx, cancel := defaultEngine.WithTimeout(auth.Context(c.Request), 0)
+			ss, err := session.FromContext(c.Request.Context(), sessions)
+			if err != nil {
+				c.AbortWithStatusJSON(http.StatusInternalServerError, c.Error(err).JSON())
+				return
+			}
+			ctx, cancel := ss.Engine.WithTimeout(auth.Context(c.Request), 0)
 			defer cancel()
 			c.Request = c.Request.WithContext(ctx)
 			c.Next()

--- a/pkg/config/configs_test.go
+++ b/pkg/config/configs_test.go
@@ -18,7 +18,7 @@ func TestLoad(t *testing.T) {
 			Source:  "testdata/config.json",
 			Include: []string{"config1.yaml", "config.json", "config2.yaml"},
 			Tuning: &Tuning{
-				RequestTimeout: &Duration{Duration: time.Second},
+				RequestTimeout: Duration(time.Second),
 			},
 		},
 		{

--- a/pkg/config/duration.go
+++ b/pkg/config/duration.go
@@ -9,12 +9,10 @@ import (
 )
 
 // Duration is a time.Duration with JSON marshal/unmarshal using [time.ParseDuration] format.
-type Duration struct {
-	time.Duration
-}
+type Duration time.Duration
 
 func (d Duration) MarshalJSON() ([]byte, error) {
-	return json.Marshal(d.String())
+	return json.Marshal(time.Duration(d).String())
 }
 
 func (d *Duration) UnmarshalJSON(b []byte) error {
@@ -24,14 +22,15 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 	}
 	switch v := v.(type) {
 	case float64:
-		d.Duration = time.Duration(v * float64(time.Second))
+		*d = Duration(v * float64(time.Second))
 		return nil
 	case string:
 		var err error
-		d.Duration, err = time.ParseDuration(v)
+		td, err := time.ParseDuration(v)
 		if err != nil {
 			return err
 		}
+		*d = Duration(td)
 		return nil
 	default:
 		return errors.New("invalid duration")

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -2,10 +2,6 @@
 
 package config
 
-import (
-	"github.com/korrel8r/korrel8r/pkg/ptr"
-)
-
 // Config defines the configuration for an instance of korrel8r.
 // Configuration files may be JSON or YAML.
 type Config struct {
@@ -22,6 +18,8 @@ type Config struct {
 	Include []string `json:"include,omitempty"`
 
 	// Tuning section has limits and optimizations.
+	// NOTE: This section is only allowed in the top-level configuration.
+	// It is not allowed in included configuration files.
 	Tuning *Tuning `json:"tuning,omitempty"`
 
 	// Soure of configuration, file or URL.
@@ -101,25 +99,13 @@ type Class struct {
 // Tuning section for limits and optimizations.
 type Tuning struct {
 	// RequestTimeout cancels requests if they last longer than this timeout.
-	RequestTimeout *Duration `json:"requestTimeout,omitempty"`
+	// If omitted or 0, requests never time out.
+	RequestTimeout Duration `json:"requestTimeout,omitempty"`
 
-	// SessionTimeout sets the idle timeout for sessions, no timeout if not set.
+	// SessionTimeout sets the idle timeout for sessions.
+	// If omitted or 0, sessions never time out.
 	//
-	// Each unique Authorization header maps to a session with its own Engine.
-	// Sessions are removed after this duration of inactivity.
-	// A value of 0 means sessions are disabled and a single shared Engine is used.
-	SessionTimeout *Duration `json:"sessionTimeout,omitempty"`
-}
-
-// Copy all non-nil fields of x to t.
-func (t *Tuning) Copy(x *Tuning) {
-	if x == nil {
-		return
-	}
-	if x.RequestTimeout != nil {
-		t.RequestTimeout = ptr.To(*x.RequestTimeout)
-	}
-	if x.SessionTimeout != nil {
-		t.SessionTimeout = ptr.To(*x.SessionTimeout)
-	}
+	// In server mode, the Authorization header of incoming REST or MCP requests identifies a session.
+	// Each session has a separate search engine, configuration and state.
+	SessionTimeout Duration `json:"sessionTimeout,omitempty"`
 }

--- a/pkg/engine/builder.go
+++ b/pkg/engine/builder.go
@@ -153,7 +153,9 @@ func (b *Builder) Config(configs config.Configs) *Builder {
 }
 
 func (b *Builder) Tuning(t *config.Tuning) *Builder {
-	b.e.Tuning.Copy(t)
+	if t != nil {
+		b.e.Tuning = *t
+	}
 	return b
 }
 

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -166,8 +166,8 @@ func (e *Engine) execTemplate(name, tmplString string, data any) (string, error)
 // WithTimeout sets timeout on ctx, using configured default value if timeout == 0.
 // If timeout == 0 and there is no default value, the returned context has no timeout.
 func (e *Engine) WithTimeout(ctx context.Context, timeout time.Duration) (context.Context, func()) {
-	if timeout == 0 && e.Tuning.RequestTimeout != nil {
-		timeout = (*e.Tuning.RequestTimeout).Duration
+	if timeout == 0 {
+		timeout = time.Duration(e.Tuning.RequestTimeout)
 	}
 	if timeout == 0 {
 		return ctx, func() {}

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -5,7 +5,6 @@ package mcp
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"time"
 
@@ -177,9 +176,6 @@ Returns the current state of the console display, representing what the user is 
 			if err != nil {
 				return nil, nil, err
 			}
-			if err := consoleCheck(s); err != nil {
-				return nil, nil, err
-			}
 			c := &rest.Console{}
 			if err := s.Console.Get(c); err != nil {
 				return nil, nil, err
@@ -197,9 +193,6 @@ a rich graphical environment.
 		func(ctx context.Context, req *mcp.CallToolRequest, input ShowInConsoleParams) (*mcp.CallToolResult, any, error) {
 			s, err := session.FromContext(ctx, sessions)
 			if err != nil {
-				return nil, nil, err
-			}
-			if err := consoleCheck(s); err != nil {
 				return nil, nil, err
 			}
 			if err := rest.ConsoleOK(s.Engine, &input); err != nil {
@@ -231,13 +224,6 @@ func (s *Server) SSEHandler() http.Handler {
 // Per-session state is resolved per-request by tool handlers via session.FromContext.
 func (s *Server) handler(*http.Request) *mcp.Server {
 	return s.Server
-}
-
-func consoleCheck(s *session.Session) error {
-	if s.Console == nil {
-		return errors.New("not connected to console")
-	}
-	return nil
 }
 
 // logger is middleware to do debug logging of MCP methods

--- a/pkg/mcp/mcp_test.go
+++ b/pkg/mcp/mcp_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/korrel8r/korrel8r/internal/pkg/test"
 	"github.com/korrel8r/korrel8r/internal/pkg/test/mock"
+	"github.com/korrel8r/korrel8r/pkg/config"
 	"github.com/korrel8r/korrel8r/pkg/engine"
 	"github.com/korrel8r/korrel8r/pkg/rest"
 	"github.com/korrel8r/korrel8r/pkg/rest/auth"
@@ -266,8 +267,8 @@ func TestMultiSessionConsole(t *testing.T) {
 	if os.Getenv(gin.EnvGinMode) == "" {
 		gin.SetMode(gin.TestMode)
 	}
-	sessions := session.NewPool(time.Hour, func() (*engine.Engine, error) {
-		return newEngine(t), nil
+	sessions := session.NewPool(time.Hour, func() (*engine.Engine, config.Configs, error) {
+		return newEngine(t), nil, nil
 	})
 	defer sessions.Close()
 
@@ -291,12 +292,18 @@ func TestMultiSessionConsole(t *testing.T) {
 		require.Equal(t, http.StatusOK, w.Code)
 	}
 
+	getSession := func(token string) *session.Session {
+		t.Helper()
+		ctx := auth.WithToken(context.Background(), token)
+		s, err := session.FromContext(ctx, sessions)
+		require.NoError(t, err)
+		return s
+	}
+
 	getConsoleState := func(token string) rest.Console {
 		t.Helper()
-		s, err := sessions.Get(token)
-		require.NoError(t, err)
 		var c rest.Console
-		require.NoError(t, s.Console.Get(&c))
+		require.NoError(t, getSession(token).Console.Get(&c))
 		return c
 	}
 
@@ -309,10 +316,8 @@ func TestMultiSessionConsole(t *testing.T) {
 	assert.Equal(t, "mock:a:x", getConsoleState("token-A").View)
 
 	// Verify send delivers to the matching session's Updates channel.
-	sA, err := sessions.Get("token-A")
-	require.NoError(t, err)
-	sB, err := sessions.Get("token-B")
-	require.NoError(t, err)
+	sA := getSession("token-A")
+	sB := getSession("token-B")
 
 	// Send update to session A.
 	go func() { _ = sA.Console.Send(&rest.Console{View: "update-A"}) }()
@@ -341,8 +346,8 @@ func newMultiSessionRouter(t *testing.T) (*gin.Engine, session.Manager) {
 	if os.Getenv(gin.EnvGinMode) == "" {
 		gin.SetMode(gin.TestMode)
 	}
-	sessions := session.NewPool(time.Hour, func() (*engine.Engine, error) {
-		return newEngine(t), nil
+	sessions := session.NewPool(time.Hour, func() (*engine.Engine, config.Configs, error) {
+		return newEngine(t), nil, nil
 	})
 	t.Cleanup(func() { sessions.Close() })
 
@@ -473,7 +478,8 @@ func TestMultiSession_SSEIsolation(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// Send update to session A only.
-	sA, err := sessions.Get("token-A")
+	ctx := auth.WithToken(context.Background(), "token-A")
+	sA, err := session.FromContext(ctx, sessions)
 	require.NoError(t, err)
 	go func() { _ = sA.Console.Send(&rest.Console{View: "update-for-A"}) }()
 

--- a/pkg/rest/operations.go
+++ b/pkg/rest/operations.go
@@ -26,7 +26,6 @@ var log = logging.Log()
 type API struct {
 	Sessions session.Manager
 	Router   *gin.Engine
-	BasePath string
 }
 
 // getSession returns the per-request Session from the context.
@@ -43,13 +42,12 @@ func New(sessions session.Manager, r *gin.Engine) (*API, error) {
 	api := &API{
 		Sessions: sessions,
 		Router:   r,
-		BasePath: BasePath,
 	}
-	rg := r.Group(api.BasePath)
+	rg := r.Group(BasePath)
 	rg.Use(api.logger) // Apply logger only to API endpoints
 	RegisterHandlers(rg, api)
 	// Helpful endpoints showing routes.
-	r.GET(api.BasePath, func(c *gin.Context) { spec, _ := GetSwagger(); c.JSON(http.StatusOK, spec) })
+	r.GET(BasePath, func(c *gin.Context) { spec, _ := GetSwagger(); c.JSON(http.StatusOK, spec) })
 	r.GET("/", api.homePage)
 	return api, nil
 }
@@ -241,7 +239,6 @@ func (a *API) ConsoleUpdates(c *gin.Context) {
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Allow-Headers", "Cache-Control")
-
 	w.Flush() // Send headers to start the SSE stream.
 
 	session, err := a.getSession(c)
@@ -252,10 +249,6 @@ func (a *API) ConsoleUpdates(c *gin.Context) {
 	keepAliveTicker := time.NewTicker(time.Minute)
 	defer keepAliveTicker.Stop()
 	for {
-		if !check(c, http.StatusInternalServerError, err) {
-			log.V(3).Info("Console update write failed", "error", err)
-			return
-		}
 		select {
 		case update, ok := <-cs.Updates: // Wait for an update
 			if !ok {
@@ -263,12 +256,18 @@ func (a *API) ConsoleUpdates(c *gin.Context) {
 				return // Shut down
 			}
 			_, err = fmt.Fprintf(w, "event: console-update\ndata: %v\n\n", string(update))
+			if !check(c, http.StatusInternalServerError, err) {
+				return
+			}
 			w.Flush()
 			log.V(3).Info("Console update sent", "event", string(update))
 
 		case <-keepAliveTicker.C:
 			// Send a keep-alive comment
 			_, err = fmt.Fprint(w, ":keepalive\n\n")
+			if !check(c, http.StatusInternalServerError, err) {
+				return
+			}
 			w.Flush()
 
 		case <-c.Request.Context().Done(): // Client disconnect

--- a/pkg/rest/rest_test.go
+++ b/pkg/rest/rest_test.go
@@ -244,20 +244,6 @@ func TestConsoleState(t *testing.T) {
 	assert.Equal(t, "test", got2.View)
 }
 
-func TestConsoleUpdatesSend(t *testing.T) {
-	cs := session.NewConsoleState()
-
-	// Send with no receiver times out
-	view := "test"
-	err := cs.Send(&Console{View: view})
-	assert.Error(t, err)
-
-	// Send with receiver succeeds
-	go func() { <-cs.Updates }()
-	err = cs.Send(&Console{View: view})
-	assert.NoError(t, err)
-}
-
 func TestDeepCopy(t *testing.T) {
 	view := "hello"
 	src := Console{View: view}
@@ -274,12 +260,13 @@ func TestMultiSession_QueryIsolation(t *testing.T) {
 	// Each session gets a separate engine with different store data.
 	// Verify that REST requests with different auth tokens get different results.
 	var callCount atomic.Int32
-	factory := func() (*engine.Engine, error) {
+	factory := func() (*engine.Engine, config.Configs, error) {
 		n := callCount.Add(1)
 		d := mock.NewDomain("mock", "a")
 		s := mock.NewStore(d)
 		s.AddQuery("mock:a:q", fmt.Sprintf("result-%d", n))
-		return engine.Build().Domains(d).Stores(s).Engine()
+		e, err := engine.Build().Domains(d).Stores(s).Engine()
+		return e, nil, err
 	}
 	sessions := session.NewPool(time.Hour, factory)
 	defer sessions.Close()

--- a/pkg/session/console.go
+++ b/pkg/session/console.go
@@ -6,28 +6,35 @@ import (
 	"encoding/json"
 	"errors"
 	"sync"
-	"time"
 )
 
-// ConsoleState shared by REST and MCP operations.
-// Holds console state reported via REST, makes available to agents via MCP.
-// Receives console updates from MCP and makes the available to REST.
+// Console connection between REST and MCP operations.
 //
-// State is stored as JSON internally, so Get/Set/Send perform
-// automatic deep copies via JSON marshal/unmarshal.
-type ConsoleState struct {
+// Holds console state put via REST, makes it available to get_console MCP tool.
+// Receives console updates from show_in_console MCP tool, and makes available as SSE events in REST.
+//
+// State values are JSON-encoded any, so the types can change without updating this code.
+type Console struct {
 	data    json.RawMessage
 	Updates chan json.RawMessage
-	m       sync.Mutex
+
+	closeOnce sync.Once
+	m         sync.Mutex
 }
 
-func NewConsoleState() *ConsoleState {
-	return &ConsoleState{Updates: make(chan json.RawMessage)}
+func NewConsoleState() *Console {
+	return &Console{Updates: make(chan json.RawMessage, 1)}
+}
+
+func (c *Console) Close() {
+	c.closeOnce.Do(func() {
+		close(c.Updates)
+	})
 }
 
 // Get unmarshals the current console state into dst, which should be a pointer.
 // If no state has been set, dst is not modified and nil is returned.
-func (c *ConsoleState) Get(dst any) error {
+func (c *Console) Get(dst any) error {
 	c.m.Lock()
 	defer c.m.Unlock()
 	if c.data == nil {
@@ -37,7 +44,7 @@ func (c *ConsoleState) Get(dst any) error {
 }
 
 // Set the console state by marshaling src to JSON.
-func (c *ConsoleState) Set(state any) error {
+func (c *Console) Set(state any) error {
 	b, err := json.Marshal(state)
 	if err != nil {
 		return err
@@ -49,8 +56,8 @@ func (c *ConsoleState) Set(state any) error {
 }
 
 // Send an update to the console.
-// Updates are dropped if they are not handled promptly.
-func (c *ConsoleState) Send(update any) error {
+// Returns error if there is already an update being sent.
+func (c *Console) Send(update any) error {
 	b, err := json.Marshal(update)
 	if err != nil {
 		return err
@@ -58,7 +65,7 @@ func (c *ConsoleState) Send(update any) error {
 	select {
 	case c.Updates <- b:
 		return nil
-	case <-time.After(time.Second):
-		return errors.New("no console connected, update not sent")
+	default:
+		return errors.New("console connection is busy, try again")
 	}
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -7,7 +7,10 @@ package session
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/korrel8r/korrel8r/internal/pkg/logging"
@@ -22,25 +25,36 @@ var log = logging.Log()
 type Manager interface {
 	// Get returns the Session for the given key, creating a new session if needed.
 	Get(key string) (*Session, error)
-	// OnExpire registers a callback that is called when a session expires.
-	OnExpire(f func(key string))
 	// Close releases resources associated with the manager.
 	Close()
 }
 
-// FromContext get the session key from the auth token in a context.
+// FromContext gets the session for the auth token in a context.
+//
+// The token is hashed before use as a session key to avoid storing raw credentials in memory.
+// If no auth token is present, all unauthenticated requests share a single session keyed by "".
 func FromContext(ctx context.Context, mgr Manager) (*Session, error) {
 	token, _ := auth.Token(ctx)
-	return mgr.Get(token)
+	return mgr.Get(hashKey(token))
 }
 
-// Session holds per-user state including engine, console, and configuration.
+// hashKey returns a hex-encoded SHA-256 hash of the key, or "" for an empty key.
+// Used to avoid storing security-sensitive tokens in memory or logs.
+func hashKey(key string) string {
+	if key == "" {
+		return ""
+	}
+	h := sha256.Sum256([]byte(key))
+	return hex.EncodeToString(h[:])
+}
+
+// Session holds per-user state including engine, console state, and configuration.
 type Session struct {
 	Engine  *engine.Engine
 	Configs config.Configs
-	Console *ConsoleState // nil if no console is connected.
+	Console *Console // nil if no console is connected.
 
-	lastUsed time.Time
+	lastUsed atomic.Int64 // UnixNano timestamp, atomic for lock-free access.
 }
 
 // singleManager always returns the same session, ignoring the key.
@@ -54,117 +68,91 @@ func NewSingle(e *engine.Engine, configs config.Configs) Manager {
 }
 
 func (m *singleManager) Get(string) (*Session, error) { return m.session, nil }
-func (m *singleManager) OnExpire(func(string))        {}
-func (m *singleManager) Close()                       {}
+func (m *singleManager) Close()                       { m.session.Console.Close() }
+
+// entry holds a session that is initialized exactly once.
+// Concurrent callers block on once.Do until the session is ready.
+type entry struct {
+	once    sync.Once
+	session *Session
+	err     error
+}
 
 // poolManager maps session keys to Sessions, with timeout-based cleanup.
 type poolManager struct {
-	mu       sync.Mutex
-	sessions map[string]*Session
-	timeout  time.Duration
-	factory  func() (*engine.Engine, error)
-	done     chan struct{}
-	onExpire []func(key string) // called when a session expires
+	sessions    sync.Map // map[string]*entry
+	factory     func() (*engine.Engine, config.Configs, error)
+	timeout     time.Duration
+	lastCleanup atomic.Int64
 }
 
 // NewPool creates a Manager that creates a new Session per key using factory
 // and expires sessions after timeout of inactivity.
-func NewPool(timeout time.Duration, factory func() (*engine.Engine, error)) Manager {
-	m := &poolManager{
-		sessions: make(map[string]*Session),
-		timeout:  timeout,
-		factory:  factory,
-		done:     make(chan struct{}),
+// timeout == 0 means never time out.
+func NewPool(timeout time.Duration, factory func() (*engine.Engine, config.Configs, error)) Manager {
+	return &poolManager{
+		timeout: timeout,
+		factory: factory,
 	}
-	tick := min(timeout/2, time.Minute)
-	go m.cleanupLoop(tick)
-	return m
 }
 
 // Get returns the Session for the given session key, creating a new session if needed.
 func (m *poolManager) Get(key string) (*Session, error) {
-	// Already in cache?
-	if s := m.get(key); s != nil {
-		return s, nil
+	v, _ := m.sessions.LoadOrStore(key, &entry{})
+	e := v.(*entry)
+	e.once.Do(func() {
+		var eng *engine.Engine
+		var configs config.Configs
+		eng, configs, e.err = m.factory()
+		if e.err == nil {
+			e.session = &Session{Engine: eng, Configs: configs, Console: NewConsoleState()}
+			log.V(1).Info("Session created", "key", key)
+		}
+	})
+	if e.err != nil {
+		log.Error(e.err, "Session create failed", "key", key)
+		m.sessions.CompareAndSwap(key, e, &entry{}) // Allow retry with a fresh entry.
+		return nil, e.err
 	}
-	// Create engine outside of the lock.
-	e, err := m.factory()
-	if err != nil {
-		log.Error(err, "Session create failed", "key", key)
-		return nil, err
-	}
-	// Lock to write a new session.
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	// Double check, session created by another goroutine.
-	if existing := m.getLH(key); existing != nil {
-		// Forget the engine we created, garbage collector will clean it up.
-		return existing, nil
-	}
-	s := &Session{Engine: e, Console: NewConsoleState(), lastUsed: time.Now()}
-	m.sessions[key] = s
-	log.V(1).Info("Session created", "key", key)
-	return s, nil
+	now := time.Now().UnixNano()
+	e.session.lastUsed.Store(now)
+	m.maybeCleanup(now)
+	return e.session, nil
 }
 
-// OnExpire registers a callback that is called when a session expires.
-// The callback receives the session key. It is called without the Manager lock held.
-func (m *poolManager) OnExpire(f func(key string)) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.onExpire = append(m.onExpire, f)
-}
-
-// get returns session for key or nil. Takes lock.
-func (m *poolManager) get(key string) *Session {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.getLH(key)
-}
-
-// getLH returns session for key or nil. Must be called with the lock held.
-func (m *poolManager) getLH(key string) *Session {
-	if s := m.sessions[key]; s != nil {
-		s.lastUsed = time.Now()
-		return s
-	}
-	return nil
-}
-
-// Close stops the cleanup goroutine.
+// Close closes all sessions.
 func (m *poolManager) Close() {
-	close(m.done)
+	m.sessions.Range(func(key, value any) bool {
+		if ent := value.(*entry); ent.session != nil {
+			ent.session.Console.Close()
+		}
+		m.sessions.Delete(key)
+		return true
+	})
 }
 
-func (m *poolManager) cleanupLoop(tick time.Duration) {
-	ticker := time.NewTicker(tick)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			m.cleanup()
-		case <-m.done:
-			return
-		}
+// maybeCleanup runs cleanup if timeout is enabled and enough time has passed since the last cleanup.
+//
+// Note this allows sessions to hang around longer if there is no activity, but in that case the
+// server is not under pressure and the number of sessions is not growing.
+func (m *poolManager) maybeCleanup(now int64) {
+	if m.timeout <= 0 {
+		return
 	}
-}
-
-func (m *poolManager) cleanup() {
-	m.mu.Lock()
-	var expired []string
-	now := time.Now()
-	for key, s := range m.sessions {
-		if now.Sub(s.lastUsed) > m.timeout {
-			delete(m.sessions, key)
-			expired = append(expired, key)
-		}
+	last := m.lastCleanup.Load()
+	if now-last < int64(m.timeout) {
+		return
 	}
-	callbacks := m.onExpire
-	m.mu.Unlock()
-	for _, key := range expired {
-		for _, f := range callbacks {
-			f(key)
-		}
-		log.V(1).Info("Session expired", "key", key)
+	if !m.lastCleanup.CompareAndSwap(last, now) {
+		return // Another goroutine is already cleaning up.
 	}
+	m.sessions.Range(func(key, value any) bool {
+		ent := value.(*entry)
+		if ent.session != nil && now-ent.session.lastUsed.Load() > int64(m.timeout) {
+			log.V(1).Info("Session expired", "key", key)
+			m.sessions.Delete(key)
+			ent.session.Console.Close()
+		}
+		return true
+	})
 }

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -9,21 +9,23 @@ import (
 	"time"
 
 	"github.com/korrel8r/korrel8r/internal/pkg/test/mock"
+	"github.com/korrel8r/korrel8r/pkg/config"
 	"github.com/korrel8r/korrel8r/pkg/engine"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func testFactory() (*engine.Engine, error) {
-	return engine.Build().Domains(mock.NewDomain("mock")).Engine()
+func testFactory() (*engine.Engine, config.Configs, error) {
+	e, err := engine.Build().Domains(mock.NewDomain("mock")).Engine()
+	return e, nil, err
 }
 
 func TestGet_SameKey(t *testing.T) {
 	m := NewPool(time.Hour, testFactory)
 	defer m.Close()
-	s1, err := m.Get("token-a")
+	s1, err := m.Get("key-a")
 	require.NoError(t, err)
-	s2, err := m.Get("token-a")
+	s2, err := m.Get("key-a")
 	require.NoError(t, err)
 	assert.Same(t, s1, s2, "same key should return same session")
 }
@@ -31,53 +33,11 @@ func TestGet_SameKey(t *testing.T) {
 func TestGet_DifferentKeys(t *testing.T) {
 	m := NewPool(time.Hour, testFactory)
 	defer m.Close()
-	s1, err := m.Get("token-a")
+	s1, err := m.Get("key-a")
 	require.NoError(t, err)
-	s2, err := m.Get("token-b")
+	s2, err := m.Get("key-b")
 	require.NoError(t, err)
 	assert.NotSame(t, s1, s2, "different keys should return different sessions")
-}
-
-func TestCleanup(t *testing.T) {
-	timeout := 50 * time.Millisecond
-	m := NewPool(timeout, testFactory)
-	defer m.Close()
-
-	s1, err := m.Get("token-a")
-	require.NoError(t, err)
-	require.NotNil(t, s1)
-
-	// Wait for expiration and cleanup.
-	time.Sleep(timeout * 3)
-
-	// After cleanup, a new session should be returned.
-	s2, err := m.Get("token-a")
-	require.NoError(t, err)
-	assert.NotSame(t, s1, s2, "expired session should return a new session")
-}
-
-func TestOnExpire(t *testing.T) {
-	timeout := 50 * time.Millisecond
-	m := NewPool(timeout, testFactory)
-	defer m.Close()
-
-	var expired sync.Map
-	m.OnExpire(func(key string) {
-		expired.Store(key, true)
-	})
-
-	_, err := m.Get("token-a")
-	require.NoError(t, err)
-	_, err = m.Get("token-b")
-	require.NoError(t, err)
-
-	// Wait for expiration and cleanup.
-	time.Sleep(timeout * 3)
-
-	_, ok := expired.Load("token-a")
-	assert.True(t, ok, "token-a should have expired")
-	_, ok = expired.Load("token-b")
-	assert.True(t, ok, "token-b should have expired")
 }
 
 func TestConcurrent(t *testing.T) {


### PR DESCRIPTION
- Session: replace Mutex with sync.Map and atomic timestamp.
- Tuning, Duration: use 0 values for default instead of pointers
- consoleCheck: removed, multi-session can't tell if console is connected without trying.