### PR TITLE
# feat: add status rules to korrel8r nodes in graph results.

### DIFF
--- a/doc/gen/rest_api.adoc
+++ b/doc/gen/rest_api.adoc
@@ -1317,6 +1317,13 @@ Query with number of results.
 | Query for correlation data.
 |     
 
+| statuses
+| 
+| 
+|   List   of <<StatusCount>>
+| Statuses found on data objects for this query.
+|     
+
 |===
 
 
@@ -1418,6 +1425,35 @@ Starting point for a correlation search. It usually specifies queries to get the
 | 
 |   List   of <<string>>
 | Queries for starting objects in \&quot;domain:class:selector\&quot; format. This is the most common way to specify a starting point. 
+|     
+
+|===
+
+
+
+[#StatusCount]
+=== _StatusCount_ 
+
+Status with number of instances found.
+
+
+[.fields-StatusCount]
+[cols="2,1,1,2,4,1"]
+|===
+| Field Name| Required| Nullable | Type| Description | Format
+
+| status
+| X
+| 
+|   String  
+| Status for correlation data.
+|     
+
+| count
+| 
+| 
+|   Integer  
+| Number of instances found, omitted if none.
 |     
 
 |===

--- a/doc/korrel8r-openapi.yaml
+++ b/doc/korrel8r-openapi.yaml
@@ -560,16 +560,16 @@ components:
           x-oapi-codegen-extra-tags:
             jsonschema: "Full class name in DOMAIN:CLASS format."
         queries:
-          type: array
-          x-go-type-skip-optional-pointer: true
           description: Queries yielding results for this class.
+          type: array
           items:
             $ref: "#/components/schemas/QueryCount"
+          x-go-type-skip-optional-pointer: true
           x-oapi-codegen-extra-tags:
             jsonschema: "Queries yielding results for this class."
         count:
-          type: integer
           description: Number of results for this class, after de-duplication.
+          type: integer
           x-oapi-codegen-extra-tags:
             jsonschema: "Number of results for this class, after de-duplication."
         result:
@@ -597,6 +597,24 @@ components:
             - $ref: "#/components/schemas/Query"
           x-oapi-codegen-extra-tags:
             jsonschema: "Query for correlation data in DOMAIN:CLASS:SELECTOR format."
+        statuses:
+          description: Statuses found on data objects for this query.
+          type: array
+          items:
+            $ref: "#/components/schemas/StatusCount"
+          x-go-type-skip-optional-pointer: true
+
+    StatusCount:
+      description: Status with number of instances found.
+      type: object
+      required: [status]
+      properties:
+        status:
+          description: Status for correlation data.
+          type: string
+        count:
+          description: Number of instances found, omitted if none.
+          type: integer
 
     Rule:
       type: object

--- a/etc/korrel8r/rules/k8s.yaml
+++ b/etc/korrel8r/rules/k8s.yaml
@@ -291,3 +291,19 @@ rules:
     result:
       query: |-
         k8s:{{.spec.names.kind}}.{{(index .spec.versions 0).name}}.{{.spec.group}}:{}
+
+statusRules:
+  - name: HasFinalizer
+    start:
+      domain: k8s
+    result:
+      labels: |-
+        {{- with index .metadata "finalizers"}}Finalizer{{end}}
+
+  - name: EventType
+    start:
+      domain: k8s
+      classes: [Event.v1, Event.v1.events.k8s.io]
+    result:
+      labels: |-
+        {{- with index . "type"}}{{if ne . "Normal"}}{{.}}{{end}}{{end}}

--- a/etc/korrel8r/rules/k8s_test.go
+++ b/etc/korrel8r/rules/k8s_test.go
@@ -244,3 +244,48 @@ func TestK8sRules(t *testing.T) {
 		x.Run(t)
 	}
 }
+
+func TestK8sStatusRules(t *testing.T) {
+	for _, x := range []statusRuleTest{
+		{
+			rule:  "HasFinalizer",
+			class: "Pod",
+			start: newK8s("Pod", "ns", "pod1", k8s.Object{
+				"metadata": k8s.Object{
+					"finalizers": []any{"kubernetes.io/pv-protection"},
+				},
+			}),
+			want: []string{"Finalizer"},
+		},
+		{
+			rule:  "HasFinalizer",
+			class: "Pod",
+			start: newK8s("Pod", "ns", "pod2", nil),
+			want:  nil,
+		},
+		{
+			rule:  "EventType",
+			class: "Event.v1",
+			start: newK8s("Event.v1", "ns", "evt1", k8s.Object{
+				"type": "Warning",
+			}),
+			want: []string{"Warning"},
+		},
+		{
+			rule:  "EventType",
+			class: "Event.v1",
+			start: newK8s("Event.v1", "ns", "evt2", k8s.Object{
+				"type": "Normal",
+			}),
+			want: nil,
+		},
+		{
+			rule:  "EventType",
+			class: "Event.v1",
+			start: newK8s("Event.v1", "ns", "evt3", nil),
+			want:  nil,
+		},
+	} {
+		x.Run(t)
+	}
+}

--- a/etc/korrel8r/rules/log.yaml
+++ b/etc/korrel8r/rules/log.yaml
@@ -30,3 +30,14 @@ rules:
     result:
       query: |-
         log:{{logTypeForNamespace .metadata.namespace}}:{"namespace":"{{.metadata.namespace}}","name":"{{.metadata.name}}"}
+
+statusRules:
+  - name: LogSeverity
+    start:
+      domain: log
+    result:
+      labels: |-
+        {{- $s := or (index . "level") (index . "severity_text") ""}}
+        {{- if or (eq $s "error") (eq $s "err") (eq $s "ERROR") (eq $s "ERR") (eq $s "Error") (eq $s "critical") (eq $s "fatal") (eq $s "CRITICAL") (eq $s "FATAL")}}Error
+        {{- else if or (eq $s "warning") (eq $s "warn") (eq $s "WARNING") (eq $s "WARN") (eq $s "Warning")}}Warning
+        {{- end}}

--- a/etc/korrel8r/rules/log_test.go
+++ b/etc/korrel8r/rules/log_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/korrel8r/korrel8r/pkg/domains/k8s"
+	"github.com/korrel8r/korrel8r/pkg/domains/log"
 	"github.com/korrel8r/korrel8r/pkg/korrel8r"
 	"github.com/korrel8r/korrel8r/pkg/unique"
 	"github.com/stretchr/testify/assert"
@@ -52,6 +53,55 @@ func TestLogRules(t *testing.T) {
 			rule:  "PodToLogs",
 			start: newK8s("Pod", "kube-something", "infrastructure", nil),
 			want:  []string{`log:infrastructure:{"namespace":"kube-something","name":"infrastructure"}`},
+		},
+	} {
+		x.Run(t)
+	}
+}
+
+func TestLogStatusRules(t *testing.T) {
+	for _, x := range []statusRuleTest{
+		{
+			rule:   "LogSeverity",
+			domain: log.Domain,
+			class:  "application",
+			start:  log.Object{"level": "error", "body": "something failed"},
+			want:   []string{"Error"},
+		},
+		{
+			rule:   "LogSeverity",
+			domain: log.Domain,
+			class:  "application",
+			start:  log.Object{"level": "warning", "body": "something suspicious"},
+			want:   []string{"Warning"},
+		},
+		{
+			rule:   "LogSeverity",
+			domain: log.Domain,
+			class:  "infrastructure",
+			start:  log.Object{"severity_text": "ERROR", "body": "infra error"},
+			want:   []string{"Error"},
+		},
+		{
+			rule:   "LogSeverity",
+			domain: log.Domain,
+			class:  "infrastructure",
+			start:  log.Object{"severity_text": "WARN", "body": "infra warning"},
+			want:   []string{"Warning"},
+		},
+		{
+			rule:   "LogSeverity",
+			domain: log.Domain,
+			class:  "application",
+			start:  log.Object{"level": "info", "body": "all is well"},
+			want:   nil,
+		},
+		{
+			rule:   "LogSeverity",
+			domain: log.Domain,
+			class:  "application",
+			start:  log.Object{"body": "no severity field"},
+			want:   nil,
 		},
 	} {
 		x.Run(t)

--- a/etc/korrel8r/rules/rules_test.go
+++ b/etc/korrel8r/rules/rules_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/korrel8r/korrel8r/pkg/domains/k8s"
 	"github.com/korrel8r/korrel8r/pkg/engine"
 	"github.com/korrel8r/korrel8r/pkg/korrel8r"
+	"github.com/korrel8r/korrel8r/pkg/status"
 	slices2 "github.com/korrel8r/korrel8r/pkg/slices"
 	"github.com/korrel8r/korrel8r/pkg/unique"
 	"github.com/stretchr/testify/assert"
@@ -141,6 +142,44 @@ func (x ruleTest) Run(t *testing.T) {
 			}
 		}
 		tested(x.rule)
+	})
+}
+
+type statusRuleTest struct {
+	rule   string
+	class  string
+	domain korrel8r.Domain
+	start  korrel8r.Object
+	want   []string
+}
+
+func (x statusRuleTest) Run(t *testing.T) {
+	t.Helper()
+	t.Run(fmt.Sprintf("%v(%v)", x.rule, test.JSONString(x.start)), func(t *testing.T) {
+		t.Helper()
+		e := setup()
+		d := x.domain
+		if d == nil {
+			d = k8s.Domain
+		}
+		c := d.Class(x.class)
+		if !assert.NotNil(t, c, "missing class: "+x.class) {
+			return
+		}
+		var m status.Rule
+		for _, mm := range e.StatusRulesFor(c) {
+			if mm.Name() == x.rule {
+				m = mm
+				break
+			}
+		}
+		if !assert.NotNil(t, m, "missing status rule: "+x.rule) {
+			return
+		}
+		got, err := m.Apply(x.start)
+		if assert.NoError(t, err, x.rule) {
+			assert.Equal(t, x.want, got)
+		}
 	})
 }
 

--- a/pkg/api/gen-openapi.go
+++ b/pkg/api/gen-openapi.go
@@ -128,6 +128,9 @@ type QueryCount struct {
 
 	// Query Query for correlation data.
 	Query Query `json:"query" jsonschema:"Query for correlation data in DOMAIN:CLASS:SELECTOR format."`
+
+	// Statuses Statuses found on data objects for this query.
+	Statuses []StatusCount `json:"statuses,omitempty"`
 }
 
 // Rule Rule is a correlation rule with a list of queries and results counts found during navigation.
@@ -161,6 +164,15 @@ type Start struct {
 
 	// Queries Queries for starting objects in "domain:class:selector" format. This is the most common way to specify a starting point.
 	Queries []Query `json:"queries,omitempty" jsonschema:"Queries for starting objects in DOMAIN:CLASS:SELECTOR format."`
+}
+
+// StatusCount Status with number of instances found.
+type StatusCount struct {
+	// Count Number of instances found, omitted if none.
+	Count *int `json:"count,omitempty"`
+
+	// Status Status for correlation data.
+	Status string `json:"status"`
 }
 
 // Store Store is a map string keys and values used to connect to a store.
@@ -229,73 +241,74 @@ type ListGoalsJSONRequestBody = Goals
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xcW3PbuJL+KyjuVjmupSQ7M1WT0lvG8clmJxefKLMPG3tPQWSLwjEEMABoRyfl/77V",
-	"DfAiCpLpWMlMzeYlkSiy0Q10f32lvySZXpVagXI2mX5JSm74ChwY+vbS8HL5rnRCK/qeg82MoO/JNAk/",
-	"sEwrZ7SUQhXMLYEttFkxvaDPBlxlFOSsQFLjJE3gcyl1DsnUmQrSRCClTxWYdZImiq8gmSY6rJgmNlvC",
-	"ih9q6dLoEowTQMKAMdpExHq1YMgaEyqTVQ5MaTVacMcloyfYCqzlBVik6NYlMjzXWgJXSZp8HmleilGm",
-	"cyhAjeCzM3zkeEHr/NNqVUv0gGXu7tLEgK2kG8DtopKS/dfs3VsWHmG3wi0Z8GzJ/o7bfGC2B6xH/FcS",
-	"BnCPtzHUAsuE8gfHID/8Zu9Z5w7ZDUvp+T8hc8ldmli3lngFFYwE8qRppTPJbUS2v+HO4BqokJxleBd+",
-	"zLnjKWkqd0xY9uLdm+ev3k7PXj+fzcb1t86DuV5xodgTGBdjdv3MpkzqImUrcEZkKeMSjEuZMzyDlClw",
-	"C6lvj8eM6AU6eCRCkVV4auNLRabIVyWK9TG5fmanFzpPUvr0Akqp1ytQbszLEg1R6mLKy1KKjJN4aeLX",
-	"n/r/kjQhPqb0L1qy52OqwN1qc51cpUnJnQODO/Pxf6dX/zGlf9tjtc4IVdCpFnqEF0f2WpQjDwZcjkot",
-	"lAPjgeMuTc60shq572/8zHEHNQpUFsyR9UcsMi4RMvAxlgtbSr4O+/quBDVbioVjtzCv7zn227QJGxa4",
-	"yZb4iUv5bpFMP35J/t3AIpkm/zZpwXQSFGQy8/ffXaU9Nj8sgTmjq7kEu9TaIYaVXIGsWbMBxrxZkTwC",
-	"Ic8YkHQKzPMyfpApHHBZtIMbAbfDN4MQYcdekJbXp4Nk9zP0qQaz4aLT6mh5RHBrvRSxoGuN09n56/Oz",
-	"D+/eB2vdBQ6oic5wody2Mja/eSn8Q/iZO3YrpGTzBpVyXN/vbS1txGupPAKjhdKmJU4I7MQKrOOr0jK+",
-	"cGD8roHK6Zdx1/yTpyenv4xOfhk9Pf1w+sv0p6fTp8/Gpz/9fPr0p9P/SdLES59Mk5w7GOHjUbMdDMZf",
-	"wS3uuxQrEdnh13iZOY2uU1WrORjUkZp6CaZVlcAz4kgB5kFMD16FnIPjxj34mOawwJ9JcqLQnNT3PYBd",
-	"fMSV/wU5lG1h/XU0sIUoKuORQygvitBqW7U3nu+T+9UIWLDOtRrgg0N7hCPxUWd/wbfBAe9bg45am1hk",
-	"M6PrjfiQN7jTEhMOVvToXv+BhJJ257kxfD1YOgodP1XCQI5unkS9ipzieV5E9uCFMJA5yCk2YiGC8NDk",
-	"PWrKFkav2MxriWYvNXpYjHQggl2F5nK4r/Bh1bavoOtNfIQcIV2mdA4Pcwd7CG25go4H2BnMzsAhIfqV",
-	"LbSU+hZyxqWm5AThLC9g8Lm/r+RXH/tDdmEg13dEc4Wsl27d2E6DdIc+Uw88hzjUltK+U+0Zipcr9Sob",
-	"NRhM0rZ1gC7XJoLZKRcKIyyuNtO6HenoLoKdp3oI1OPbU4kxjKYZUdqLJuEngOJkA6O8NvxI2Mf+JlRu",
-	"Wcnd0nrz9zvchDba21ENA5EYuojz0kWPHUeVMgrXe+lIyIJ89rE7tdlMWa4GGmLQ2W9viYcRvxeBDExS",
-	"6PZtu6TrlCGgUI0L+5q84x5SWxbodaSWJKrR6IEiWkTZvDdBXI9UlO/Im3o2mBcxYH8tLGFkrx4xSHvI",
-	"sX4H5YnyiHuKwHevTHTTYJne6vwPkCnwGI9C34IolvNoPW8L4VS4d6n1PoDjUjaYZoBnSz6X4LWpdSvz",
-	"dfCZqGldWt6fViXCoc82P4tVtWI5lG4Zw0T6YZv7N+G5NufY4NhBSYjrmehxN2YvkCg7DbVQyzyud0lY",
-	"ppVce4YekR59Jzb/Itjmz3oftpGJbeckOt8RhodQwzZlEq/qVqhCgncq23CX7SlcZk0cNX5Urtkjtjeu",
-	"znQVK6G8bXSqK5yvSiHhNJQMchjlVeMUH5nvf+2iKMenCkwsp6UClADL1gJkjvoSpz0YiKmgdUa79h3g",
-	"eDD3bcMiliQZwaX4F+TdKBmlStmKr9kcmOTmAXnSu8Zmvn2mNJT1LYP3lhYz9MA+olmeC8/iRcdKPZO9",
-	"tJw7HlwTsy1T3FIjpqP4YZnOXiRTkmn8nt++8TkFMuHLslF19fXSvF3R7updNNXSb9TE6HRRNnoZgeiF",
-	"zlO2ERT3iNuSK6J9q8318ZjV7E4DnZEtIRMLkflKHvNgF1x1rHfx6A5Gx3x37D2V5lQfiiJIPhA5U4Yp",
-	"PCZ2wifHXtRbbpnSjsFnyCoH+aGxc/CyNXquH99SaJW3G4mgIn9t06BPZ2C7oIsDXrYYDlC5Z+sA8Sra",
-	"Gd+KLb1qcCZDjBx8DuMqb3CZtALhuVI5yyvUTqb4jSh2FGD3FEKRB8VqTW7rsDdwgBhh2AqDPGsBCgxH",
-	"TbtdCgzXm+CcHBTu3J/cuw6S4G5wYXfWtCv7fal+3sPa2Y8xmwGaJc+cXDOtCHyPKCM/Yk8cOjlkMDzn",
-	"NGugM5Qvjpk27KhOtPAhXaL4Koec0QRIaAg4jc4Bw+HjvYWiYVjga1zbWPDwIteD9PcryFNm3s1ZhwnY",
-	"prkDhLwvz32cjPdSjyfqs3hrLJJBRUs27JVjla24lOta6cA24Oc0K8C1mSUSbKKWeeVYxlUzA9KJnOo0",
-	"n1t2C1IybidCWQc870BrTD+bDOoQ5W+92OJ6zN4HI2e3S1CswoSOHYVfj1Dg0ugbERVnzF51/IJp+8wp",
-	"7tCarSrrqMoxh7bNTxH8pfoWCLdTyl1JYVT4RwsXUs1uy37g6bXPRI7w0X3+B2zkI9fCDQgP7bDEhmYk",
-	"vahPxbIj2lDSQpGDcmKx7jDEUHfG7LnEyJmTI3eaHYUzO/JnutYV49IAz9dsyfGWViCvhn+2JHD49vhc",
-	"Zd/mDItpEAxjJnOZ+MRlSgtNLUjInDaXSWM/H1DrhdeSlbaYsK5WWrFbvm699prxljzty67psOmXSwo0",
-	"bMkzuEyml0kOC15Jd5mk/he6uFqPSp1fJneDWywhhv9+QdauLf2a6R/foN+ZwH/ZnhmITAr4IH/Fy5B2",
-	"smtY+2D+hssKLKss5HhmmVaK9EfTsWkD2/k+8Qmfye7kC51FdOs3cq3PDPvdgmEvK5FDkiaVkck0WTpX",
-	"2ulkch3uGRfCLav5WOjm0gTFEGqhffKpHPc1jDDAe2E0KXm9yhbpQDHTq5Zk/WF7hxpm64AALNNzC+aG",
-	"z4UUbs2sKBSXTfajK5P5Hhpnv1VzMAocGWRlHRgKIsI+Wp/JUUE6F4sFGFAuFAQseyJ1YetCgg2VBBvq",
-	"FDbt0m5WPb6vJ+A0m1dC5hgnUmOD8mRJIX+LfK3MBkhgzixghO7Q1VuL9FCLadC2wkMMCWGlxKcK2H9+",
-	"+HDBnlduqY34l19+CTxH6c82RnKyJVcFClOPwlnHHaS0laRf9VZRFZ48rdWe2xJMzYuHPbBhnEhXDrO5",
-	"2PrMLpFIU5sOENIQIuyRIgNloaNSz0ueLYE9HZ88SJkmc6nnEzzNyetXZ+dvZ+cEM8LR3Fuzye/PZx/Y",
-	"84tXSZrcgLFe7W5OuSyX/JSAqCY4an8/GZ+ejE9HOdwgTUxweCmSafLT+GR86otGSzK9iZ8Covn6KhL8",
-	"vtE5wrAHcEoYugdkwSFM2VDnkrpgN2Dm2gq3PmYaddxUiqYM0CREBn4PEYKIwqvcj3n4cyfG2iH/j31m",
-	"/ptoA5NwA5JUTOqiEKqgvDkyre+ZgY1p/dDtSqanJ2myEsp/OdmqKt1hIGXAllpZD5ZPT05qTIEQnLU1",
-	"vQmCOQ3hNitFkK/3qsBvvmlUrVbcrDF6IoXftcnc4W7Wg3feiXxMmjGu5AqJTbJ29jh6orPacFqLYlaj",
-	"SfACAQbzEAx6mHDsRnD25uyCOa0lpi//CI+h+wb6JZMCH6KQtgmSLF+1SPAkZmnHGJPgraTdnshu1SB5",
-	"fFEBrPtV5+sHncN9gTNSj5xOL62kie0y58EKuoPa46Rb8QgV1G+rOme9UfGaM1tlGVi7qKSkqOXnBy68",
-	"d16ABngizAh1w6XIO1Wanl6/4dd9leM3XEhqW7tW+Xp6TSdzhRBXx09BBUZzna9HwcjDtaSr/RO4qV8b",
-	"KiBiBL/Tdnmf4YwoCsBUbl7vIzO1xyDv25iAXerbfwj13c0gnPa5F+pe3XLw2fkdGFlngK8OYg+z2Tnz",
-	"5DA/MuD9Oy1zVMcqAmTeNnw5pR0jUHh8Oat11ms1yrmpJbgAkauXoVZ9TM/DuexVG1IHHy1Nvvj/7yah",
-	"BrhTL96HLn9bvG77wy0M1NWdfOOVlc0jey2s83PGZ2HNe5zb9lAvWgaxUQ9eLbTZmI2/fmZrx4cOvfV7",
-	"/vktVEq3EaaZ1Xuss+ukZH6ibeYdfpIm7Ss7G1nXzjHLJ3WYFrahNLAQn49jI85fN3gcdcR/IFbi0j9/",
-	"+6XDdirtfN+lZ34vQ3lyQ/Ohrql25syDpYWGUcfOHmJXTXxbJzQY1PvqaGw6nbBmiLUNgMf9WzuoKhDe",
-	"LPihgQ9bOswmDNbAblfTn+4uBaR01U6apkypbSz2batKfrR8Yzw4RW9c1221iZStferJO0PEmFzWqu1T",
-	"5u5ktZRhFlkCzzsDn91lfbmEKLaOsa/fNDj6Moyd9txI7CTaWyYbL0p7mD98GB26W5Ggwdd3O7PY/Rns",
-	"g8fOe/mkudwf9he3vzOq5/S6W16r9wzT1z2ojSAsFMMeGL0HK97oPn5bS6b+bhPYbTQO67Ze38D1omPY",
-	"VNnyRLRhEqx/KaVn8RvM7bTvtoP6p7TxToN3iJ3jnjYH+cPK/4RWvqHtXre5oYGcqIcSN6DCjPjBTb3q",
-	"23ppIOOuTVz+31h/9cP8f5j/X9/8McT/g8P1OsvovkzTfdk29MiX3NfE5+BftcGEdDuK35WU1jH7Xz3o",
-	"/uYvZ/0w53vMuVbn5kVx27RuQ0N+Y47iADbcmdOJFn3O/ex0209taj40abM+Cj1xNMiNvD8y/kaij9kL",
-	"DX4uuwRDf1CLq/VGtsJ9Mzhmju8Cu/fUYf/enbDf0Vesv+4urw4YKblLH/sHWToTWgP+dFlnrix9QDeg",
-	"Hivr/6Gpq0Mhxr6XS7YmWn5Ax+Ggo7VP0pS0ecexBRP662l15BorvSFBMDe1KfnphwkvxaQZUUBNCc/t",
-	"mC4AVQjVb3vHRgrGG9oc2t7bduRN2A85y+23hMZ9Q96m8DJMum9XQuwGDzVwblP41Yi8ADYHdwugGGcv",
-	"f3/VdLOevD+ffTj20Yliz1+F1vuTN2cXx5sGS724q7v/CwAA//802bIDDFEAAA==",
+	"H4sIAAAAAAAC/+xcW3PbuJL+KyjuVjmupSQ7M1WT0lvG8cl6JxefKLMPG3tPQWSLwjEEMABoRyfl/77V",
+	"DfAiCpLpSzJTs3lJbEpsdAN9+7ob/ppkelVqBcrZZPo1KbnhK3Bg6LfXhpfL96UTWtHvOdjMCPo9mSbh",
+	"A5Zp5YyWUqiCuSWwhTYrphf0swFXGQU5K5DUOEkT+FJKnUMydaaCNBFI6XMFZp2kieIrSKaJDiumic2W",
+	"sOJPtXRpdAnGCSBhwBhtImKdLRiyxoTKZJUDU1qNFtxxyegNtgJreQEWKbp1iQzPtZbAVZImX0aal2KU",
+	"6RwKUCP44gwfOV7QOv+0WtUS3WOZ29s0MWAr6QZwu6ikZP81e/+OhVfYjXBLBjxbsr/jNj8x2wPWI/4r",
+	"CQO4x68x1ALLhPIHxyB/+s3es84tshuW0vN/QuaS2zSxbi3xCSoYCeRJ00onktuIbH/DncE1UCE5y/Bb",
+	"+GPOHU9JU7ljwrJX79++PHs3PXnzcjYb1791Xsz1igvFnsG4GLOrFzZlUhcpW4EzIksZl2BcypzhGaRM",
+	"gVtIfXM4ZkQv0MEjEYqswlMbXygyRb4qUaxPydULOz3XeZLST6+glHq9AuXGvCzREKUuprwspcg4iZcm",
+	"fv2p/y9JE+JjSv+iJXs+pgrcjTZXyWWalNw5MLgzn/53evkfU/q3PVbrjFAFnWqhR/hwZK9EOfLOgMtR",
+	"qYVyYLzjuE2TE62sRu77Gz9z3EHtBSoL5sD6IxYZl+gy8DWWC1tKvg77+r4ENVuKhWM3MK+/c+i3adNt",
+	"WOAmW+JPXMr3i2T66Wvy7wYWyTT5t0nrTCdBQSYz//3by7TH5sclMGd0NZdgl1o79GElVyBr1mxwY96s",
+	"SB6BLs8YkHQKzPMyvpcpPOGyaAfXAm6GbwZ5hB17QVpenw6S3c/Q59qZDRedVkfLI4Jb66XoC7rWOJ2d",
+	"vjk9+fj+Q7DWXc4BNdEZLpTbVsbmMy+Ffwl/5o7dCCnZvPFKOa7v97aWNhK1VB5xo4XSpiVOHtiJFVjH",
+	"V6VlfOHA+F0DldMn4675J8+Pjn8ZHf0yen788fiX6U/Pp89fjI9/+vn4+U/H/5OkiZc+mSY5dzDC16Nm",
+	"O9gZP4Bb3HcpViKyw2/wMXMaQ6eqVnMwqCM19RJMqyqBZ/QjBZh7MT14FQoOjht372OawwI/JsmJQnNS",
+	"3/cAdvERV/5XFFC2hfXP0cAWoqiM9xxCeVGEVtuqvfF+n9yvRsCCdZ7VDj4EtEcEEp919hd8FwLwvjXo",
+	"qLWJZTYzet6ID3njd1piwsGKXt0bP5BQ0u48N4avB0tHqePnShjIMcyTqJeRUzzNi8gevBIGMgc55UYs",
+	"ZBDeNfmImrKF0Ss281qi2WuNERYzHYj4rkJzOTxW+LRqO1bQ8yY/Qo6QLlM6h/uFgz2EtkJBJwLsTGZn",
+	"4JAQfcoWWkp9AznjUhM4QXeWFzD43D9U8sHHfp9dGMj1LdFcIeulWze203i6pz5T73ie4lBbSvtOtWco",
+	"Xq7Uq2zUYBCkbesAPa5NBNEpFwozLK42Yd0OOLqLYOetngfq8e2pxBhG04wo7XkD+MlBcbKBUV4bfiTt",
+	"Y38TKres5G5pvfn7HW5SG+3tqHYDkRy6iPPS9R47jipllK734EhAQR597IY2m5DlcqAhBp399pb4NOL3",
+	"MpCBIIW+vm2X9JwQAgrVhLCH4I47SG1ZoNeRWpKoRmMEimgRoXlvgrgeqSjfgZt6NpgXMcf+Rljykb16",
+	"xCDtocD6HZQnyiPuKTq+O2WiLw2W6Z3O/wCZAo/xLPQdiGI5j9bztjycCt9dar3PwXEpG59mgGdLPpfg",
+	"takNK/N1iJmoaV1aPp5WJbpDjza/iFW1YjmUbhnzifTBNvdvw3st5tjg2EFJHtcz0eNuzF4hUXYcaqGW",
+	"eb/eJWGZVnLtGXoEPPpObP5FfJs/632+jUxsG5PofEcaHlIN25RJvKpboQoJPqhsu7tsT+Eya/Ko8aOw",
+	"Zo/Y3rw601WshPKu0amucL4qhYTTUDLIYZRXTVB8JN5/6KIox+cKTAzTUgFKgGVrATJHfYnTHuyIqaB1",
+	"Qrv2HdzxYO7bhkUMJBnBpfgX5N0sGaVK2Yqv2RyY5OYeOOl9YzPfHikNZX3L4L2lxQw9sI/eLM+FZ/G8",
+	"Y6WeyR4s546H0MRsyxS31IjpKH5YprMXyZRkGn/gN289pkAmfFk2qq6+Xpq3K9pdvYumWvqNmhidLspG",
+	"LyMQPdd5yjaS4h5xW3JFtG+0uTocs5rdaaAzsiVkYiEyX8lj3tmFUB3rXTy6g9Ex3x17T6U51XdFEU8+",
+	"0HOmDCE8AjvhwbEX9YZbprRj8AWyykH+1L5z8LK191w/vqXQKm83E0FFfmjToE9nSLuAYryrbLxE6D9h",
+	"C12pnNVU65yz8apN+XpgvRCpPioo9L2XP5GY96Ii1ZZg+BS9A9/KiL1CcyZDZh8iJeMqb6IJ6XK9KXmF",
+	"NsUUvxbFjrLxnvIt8qBYLWRbPb6GJ8hshq0wKB8oQIHhaB83S4Ego4EUpAC4c3/ynGCQBLeDy9Gzpsna",
+	"76b10RprJ1bGbAboTHjm5JppRSHjgOoIB+yZw9CMDIb3nGaNww9Fl0OmDTuo4SG+pEsUX+WQM5pbCW0M",
+	"pzGkYRJ/uLe8NcyD+crctge7f2nuXvr7APJUT+gi7WECtuB8gJB3ofPHyXgn9Xh5YRZv6EVwX7TQxM4c",
+	"q2zFpVzXSge2cX5OswJci4eRYJNrzSvHMq6ayZVOvlcHCm7ZDUjJuJ0IZR3wvONaY/rZ4L6nKNrrxRbX",
+	"Y/YhGDm7WYJiFcJQdhA+PUCBS6OvRVScMTvrxAXTdsdT3KE1W1XWUW1mDu1wAuGOC/UtPNxOKXdB2ajw",
+	"jxYuAOTuoMHA02vfiRzho6cT7rGRj1wLNyC8tMMSG5oRUFSfimUHtKGkhSIH5cRi3WGIoe6M2UuJ+T6n",
+	"QO40OwhnduDPdK0rxqUBnq/ZkuNXWoG8Gv7ZoOvw7fEIa9/mDMtp0BnGTOYi8XBrSgtNLUjInDYXSWM/",
+	"H1HrhdeSlbYIs1crrdgNX7dRe814S572ZddM2/TrBSUatuQZXCTTiySHBa+ku0hS/wk9XK1Hpc4vktvB",
+	"jaGAPL5fkrVrSx8ys9SFCTuQSR99YnDhKqsBywNQaI/CBixUWkEEdzYIaieXuyDe/kZpIBpNPmniYmdF",
+	"5uv2EEhk9MPjnxUvQx2BXcHa45xrLiuwrLKQozpnWikyLU0arQ1sF3DoCOELuST5SmeRzfiNduCFYb9b",
+	"MOx1JXJI0qQyMpkmS+dKO51MrsJ3xoVwy2o+Frp5NEExhFpof47KcV+UChPZ50aT/derbJEOFDO9aknW",
+	"P2zvUMNsfW5gmZ5bMNd8LqRwa2ZFobhsgKGuTOabopz9Vs3BKHDkqyrrwFB+FfbRehBNHYZcLBZgQLlQ",
+	"4bHsmdSFrStDNpSGbCg82bRLu1n18K4mj9NsXgmZYwpNnSoqfEhCQ21QaGU2QAJzZgHBi8MsyFqkh6pM",
+	"k9MVHmLAypUSnytg//nx4zl7WbmlNuJffvkl8BylP9mYscqWXBUoTD3biKoOKW0l6Ve9VdRWoSTEas9t",
+	"CabmxUcEsGE+TFcOgW5sfWaXSKRpNgTv2hAityxFBspCR6VeljxbAns+PrqXMk3mUs8neJqTN2cnp+9m",
+	"p+SBhaNBxmaTP5zOPrKX52dJmlyDsV7tro+5LJf8mHx0TXDUfn40Pj4aH49yuEaaiP14KZJp8tP4aHzs",
+	"q4BLMr2JH+uiCxNVxOO91TlGKB/bCEt1D8iCQw9uQ+FS6oJdg5lrK9z6kGnUcVMpGhtBkxAZ+D1EF0QU",
+	"znI/t+PPnRhrb2186jPz30QbmIRrkKRiUheFUAWVFCLXLzwzsHH9IrQvk+nxUZqshPK/HG27a8wxDdhS",
+	"q1Dzen50VPsUCHlrW6SdYJyjqepmpYjn6939+M3X1arVips1Jpak8Ls2mTvczXqS0sfXT0kzl5dcIrFJ",
+	"1g6TR090VhtOa1HMajQJXqCDQYiG+SATjl0Lzt6enDOntURk94/wGmY2QJ9kUuBLlO03+aPlq9YTPItZ",
+	"2iGma/hV0m5PZLdqkDw+6IF1v+p8fa9zuAtTIPXI6fQQN43glzkPVtCdvB8n3YgcSuLfVnVOerP/NWe2",
+	"yjKwdlFJSQndz/dceO8ACE1kRZgR6ppLkXcKWD29fsuv+irHr7mQNIfgWuXr6TWdzCW6uDq1DCowmut8",
+	"PQpGHp4lXe2fwHV9D6yAiBH8TtvlY4YzoigAUe683kdm6ohB0bcxAbvUN/8Q6rubQTjtUy/Unbrl4Ivz",
+	"OzCyzgBfPYk9zGanzJND6GjAx3da5qDOVQTIvO3gc0JkI1B4fDmrddZrNcq5qSW4AJGrl6HZi5ieh3PZ",
+	"qzakDj5bmnz1/99OQnl0p158CGMbbV2/bfi3bqAufOUbd5A2j+yNsM4Pjp+ENe8IbttT2mgZxEY9SbfQ",
+	"ZuOyw9ULWwc+DOht3PPvb3mldNvDNJjiscGug1b9iOLMB/wkTdo7WBuAdOfc7LM6TQvbUBpYiC+HsZn1",
+	"h/WEooH4D/SVuPTP337psJ1KOw9ae+b3OlRuNzQf6nJz5+JAsLTQS+vY2X3sqslva0CDSb0vHMeuG5Cv",
+	"GWJtA9zj/q0dVDAJV0V+aOD9lg7DJoM1sFsL8ae7SwEJrtpJ068qtY3lvm3Bzd8V2Jj3TjEa1yVtbSIV",
+	"fQ89eWcqHMFlrdoeMndH5aUMw+USeN6Z4O0u68slRLENjH39pkng12GOuBdGYifRfmWycfPdu/mnT6ND",
+	"4y+SNPjSd2e4vj9U/+S5814+adD6h/3F7e+E6jm9xp/X6j23I+r23EYSFoph98zegxVvNGa/rSVT67tJ",
+	"7DZ6qnXHs2/getExbKpseSLaMAnW3zLqWfwGczvtu20u/yltvNP7HmLnuKfNQf6w8j+hlW9ou9dtbmhW",
+	"KRqhxDWoMPT/5KZe9W29NJBx1wKX/zfWX/0w/x/m/9c3f0zx/+B0vUYZ3dtR3dvTYXxgyX1NfA7+7hQC",
+	"0u0sfhcorXP2v3rS/c1v2/0w5zvMuVbn5ua/bVq3oSG/MWLyBDbcGWGKFn1O/TB8209taj40hLQ+CD1x",
+	"NMgN3B+ZDPRzGuyVBj9oX4Khv5DG1XoDrXDfDI6Z4/vA7h112L93r0zs6CvWv+4urw6YtrlNH/sXdjrD",
+	"awP+Fl1n5C69Rzegnrjr/+Wwy6fyGPtuC21NtPxwHU/nOlr7JE1Jm0urrTOhP4dXZ66x0hsSBHNdm5Kf",
+	"fpjwUkyaEQXUlPDejukCUIVQ/bZ3bKRgvKHNoe29bUfehP38t9y+9jXuG/I2hdfhEsB2JcRu8FA7zm0K",
+	"vxqRF8Dm4G4AFOPs9e9nTTfr2YfT2cdDn50o9vIstN6fvT05P9w0WOrFXd7+XwAAAP//98tL5N1SAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/config/configs_test.go
+++ b/pkg/config/configs_test.go
@@ -82,6 +82,29 @@ func TestConfigs_Expand(t *testing.T) {
 	assert.Equal(t, want, c)
 }
 
+func TestLoad_statusRules(t *testing.T) {
+	c, err := Load("testdata/status-rules.yaml")
+	require.NoError(t, err)
+	want := Configs{
+		{
+			Source: "testdata/status-rules.yaml",
+			StatusRules: []StatusRule{
+				{
+					Name:   "HasFinalizer",
+					Start:  ClassSpec{Domain: "k8s"},
+					Result: LabelResultSpec{Labels: "{{- with .metadata.finalizers}}has-finalizer{{end}}"},
+				},
+				{
+					Name:   "PodPhase",
+					Start:  ClassSpec{Domain: "k8s", Classes: []string{"Pod"}},
+					Result: LabelResultSpec{Labels: "phase-{{.status.phase}}"},
+				},
+			},
+		},
+	}
+	assert.Equal(t, want, c)
+}
+
 func TestConfigs_Expand_sameGroupDifferentDomain(t *testing.T) {
 	c := Configs{
 		{

--- a/pkg/config/testdata/status-rules.yaml
+++ b/pkg/config/testdata/status-rules.yaml
@@ -1,0 +1,14 @@
+statusRules:
+  - name: HasFinalizer
+    start:
+      domain: k8s
+    result:
+      labels: |-
+        {{- with .metadata.finalizers}}has-finalizer{{end}}
+  - name: PodPhase
+    start:
+      domain: k8s
+      classes: [Pod]
+    result:
+      labels: |-
+        phase-{{.status.phase}}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -17,6 +17,9 @@ type Config struct {
 	// Include lists additional configuration files or URLs to include.
 	Include []string `json:"include,omitempty"`
 
+	// StatusRules generate statuses from Objects to annotate graph nodes.
+	StatusRules []StatusRule `json:"statusRules,omitempty"`
+
 	// Tuning section has limits and optimizations.
 	// NOTE: This section is only allowed in the top-level configuration.
 	// It is not allowed in included configuration files.
@@ -82,7 +85,7 @@ type ClassSpec struct {
 
 // ResultSpec contains templates to generate a result.
 type ResultSpec struct {
-	// Query template generates a query object suitable for the goal store.
+	// Query template generates a query string suitable for the goal store.
 	Query string `json:"query"`
 }
 
@@ -94,6 +97,27 @@ type Class struct {
 	Domain string `json:"domain"`
 	// Classes are the names of classes in this group.
 	Classes []string `json:"classes"`
+}
+
+// StatusRule configures a template that generates statuses for graph nodes.
+//
+// The template is applied to objects of the start class. It should generate newline-separated
+// label strings. Each unique label gets a count of how many times it appeared.
+type StatusRule struct {
+	// Name is a short, descriptive name.
+	Name string `json:"name,omitempty"`
+
+	// Start specifies the set of classes that this rule can apply to.
+	Start ClassSpec `json:"start"`
+
+	// Result contains the template to generate labels.
+	Result LabelResultSpec `json:"result"`
+}
+
+// LabelResultSpec contains a template to generate labels.
+type LabelResultSpec struct {
+	// Labels template generates newline-separated label strings.
+	Labels string `json:"labels"`
 }
 
 // Tuning section for limits and optimizations.

--- a/pkg/engine/builder.go
+++ b/pkg/engine/builder.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Masterminds/sprig/v3"
 	"github.com/korrel8r/korrel8r/pkg/config"
 	"github.com/korrel8r/korrel8r/pkg/korrel8r"
+	"github.com/korrel8r/korrel8r/pkg/status"
 	"github.com/korrel8r/korrel8r/pkg/rules"
 	"github.com/korrel8r/korrel8r/pkg/unique"
 )
@@ -36,6 +37,7 @@ func Build() *Builder {
 		domains:      korrel8r.Domains{},
 		storeHolders: map[korrel8r.Domain]*storeHolders{},
 		rulesByName:  map[string]korrel8r.Rule{},
+		statuses:     map[string][]status.Rule{},
 	}
 	// Add template functions that are always available.
 	e.templateFuncs = globalTemplateFuncs(e)
@@ -198,6 +200,12 @@ func (b *Builder) config(c *config.Config) {
 		// Defer adding rules until domains and stores are configured.
 		b.finally = append(b.finally, func() { b.configRule(r) })
 	}
+	for _, lr := range c.StatusRules {
+		if b.err != nil {
+			return
+		}
+		b.finally = append(b.finally, func() { b.configStatusRule(lr) })
+	}
 }
 
 func (b *Builder) configRule(r config.Rule) {
@@ -209,8 +217,8 @@ func (b *Builder) configRule(r config.Rule) {
 			b.err = fmt.Errorf("invalid rule %v: %w", r.Name, b.err)
 		}
 	}()
-	start := b.classes(r, &r.Start)
-	goal := b.classes(r, &r.Goal)
+	start := b.classes(r.Name, &r.Start)
+	goal := b.classes(r.Name, &r.Goal)
 	if len(start) == 0 || len(goal) == 0 {
 		return
 	}
@@ -222,7 +230,32 @@ func (b *Builder) configRule(r config.Rule) {
 	b.rules(rules.NewTemplateRule(start, goal, tmpl))
 }
 
-func (b *Builder) classes(r config.Rule, spec *config.ClassSpec) []korrel8r.Class {
+func (b *Builder) configStatusRule(r config.StatusRule) {
+	if b.err != nil {
+		return
+	}
+	defer func() {
+		if b.err != nil {
+			b.err = fmt.Errorf("invalid label rule %v: %w", r.Name, b.err)
+		}
+	}()
+	start := b.classes(r.Name, &r.Start)
+	if len(start) == 0 {
+		return
+	}
+	var tmpl *template.Template
+	tmpl, b.err = b.e.NewTemplate(r.Name).Parse(r.Result.Labels)
+	if b.err != nil {
+		return
+	}
+	lb := status.New(start, tmpl)
+	for _, c := range start {
+		key := c.String()
+		b.e.statuses[key] = append(b.e.statuses[key], lb)
+	}
+}
+
+func (b *Builder) classes(name string, spec *config.ClassSpec) []korrel8r.Class {
 	var d korrel8r.Domain
 	d, b.err = b.e.Domain(spec.Domain)
 	if b.err != nil {
@@ -236,7 +269,7 @@ func (b *Builder) classes(r config.Rule, spec *config.ClassSpec) []korrel8r.Clas
 				// A missing class is not a fatal error, because some domains (k8s)
 				// may have different sets of classes (custom resources) for different clusters
 				// Collect and log a report at end of configuration.
-				b.missingClasses[class] = append(b.missingClasses[class], r.Name)
+				b.missingClasses[class] = append(b.missingClasses[class], name)
 			} else {
 				list.Append(c)
 			}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -15,6 +15,7 @@ import (
 	"github.com/korrel8r/korrel8r/pkg/config"
 	"github.com/korrel8r/korrel8r/pkg/graph"
 	"github.com/korrel8r/korrel8r/pkg/korrel8r"
+	"github.com/korrel8r/korrel8r/pkg/status"
 )
 
 var log = logging.Log()
@@ -27,6 +28,7 @@ type Engine struct {
 	templateFuncs template.FuncMap
 	rulesByName   map[string]korrel8r.Rule
 	rules         []korrel8r.Rule
+	statuses      map[string][]status.Rule // Keyed by class.String()
 
 	// Tuning parameters
 	Tuning config.Tuning
@@ -117,6 +119,9 @@ func (e *Engine) Queries(queryStrings []string) ([]korrel8r.Query, error) {
 func (e *Engine) Rules() []korrel8r.Rule { return slices.Clone(e.rules) }
 
 func (e *Engine) Rule(name string) korrel8r.Rule { return e.rulesByName[name] }
+
+// StatusRulesFor returns the status rules for the given class.
+func (e *Engine) StatusRulesFor(c korrel8r.Class) []status.Rule { return e.statuses[c.String()] }
 
 // Graph creates a new graph of the engine's rules.
 func (e *Engine) Graph() *graph.Graph { return graph.NewData(e.Rules()...).FullGraph() }

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/korrel8r/korrel8r/internal/pkg/test/mock"
+	"github.com/korrel8r/korrel8r/pkg/config"
 	"github.com/korrel8r/korrel8r/pkg/engine"
 	"github.com/korrel8r/korrel8r/pkg/engine/traverse"
 	"github.com/korrel8r/korrel8r/pkg/korrel8r"
@@ -153,6 +154,46 @@ func TestEngineStoreFor(t *testing.T) {
 	q = mock.NewQuery(d.Class("bar"), "help")
 	require.NoError(t, e.StoreFor(d).Get(context.Background(), q, nil, r))
 	assert.ElementsMatch(t, []korrel8r.Object{"help", "me"}, r.List())
+}
+
+func TestEngine_LabelersFor(t *testing.T) {
+	d := mock.NewDomain("mock", "a", "b")
+	a := d.Class("a")
+	b := d.Class("b")
+	s := mock.NewStore(d, a, b)
+	e, err := engine.Build().Domains(d).Stores(s).
+		Config(config.Configs{
+			{
+				Rules: []config.Rule{{
+					Name:   "ab",
+					Start:  config.ClassSpec{Domain: "mock", Classes: []string{"a"}},
+					Goal:   config.ClassSpec{Domain: "mock", Classes: []string{"b"}},
+					Result: config.ResultSpec{Query: `mock:b:x`},
+				}},
+				StatusRules: []config.StatusRule{
+					{
+						Name:   "label-a",
+						Start:  config.ClassSpec{Domain: "mock", Classes: []string{"a"}},
+						Result: config.LabelResultSpec{Labels: `label-from-a`},
+					},
+					{
+						Name:   "label-a2",
+						Start:  config.ClassSpec{Domain: "mock", Classes: []string{"a"}},
+						Result: config.LabelResultSpec{Labels: `another-label`},
+					},
+				},
+			},
+		}).Engine()
+	require.NoError(t, err)
+
+	// Class a should have 2 labelers
+	statuses := e.StatusRulesFor(a)
+	assert.Len(t, statuses, 2)
+	assert.Equal(t, "label-a", statuses[0].Name())
+	assert.Equal(t, "label-a2", statuses[1].Name())
+
+	// Class b should have no status rules
+	assert.Empty(t, e.StatusRulesFor(b))
 }
 
 // Mock object has a name and a timestamp.

--- a/pkg/engine/traverse/traverse.go
+++ b/pkg/engine/traverse/traverse.go
@@ -170,7 +170,8 @@ func (w *worker) Run(ctx context.Context) {
 		w.inbox.Clear()
 		w.processed = len(w.node.Result.List())
 	}()
-	// Process queries from inbox
+	// Process queries from inbox, apply status rules per query.
+	statusRules := w.engine.StatusRulesFor(w.node.Class)
 	for _, ql := range w.inbox.List {
 		if ctx.Err() != nil {
 			return
@@ -183,23 +184,32 @@ func (w *worker) Run(ctx context.Context) {
 		if ql.Line != nil {
 			ql.Line.Queries.Set(ql.Query, len(result))
 		}
+		statusCounts := map[string]int{}
+		for _, o := range result {
+			for _, r := range statusRules {
+				statuses, _ := r.Apply(o)
+				for _, s := range statuses {
+					statusCounts[s]++
+				}
+			}
+		}
+		if len(statusCounts) > 0 {
+			w.node.Queries.AddStatuses(ql.Query, statusCounts)
+		}
 	}
 
-	// Apply rules to un-processed results, generate queries in outbox.
+	// Apply correlation rules to un-processed results, generate queries in outbox.
 	for _, o := range w.node.Result.List()[w.processed:] {
 		for _, r := range w.rules.List {
 			if ctx.Err() != nil {
 				return
 			}
 			queries, err := r.Apply(o)
-			if err != nil || len(queries) == 0 {
-				log.V(4).Info("Rule did not apply", "rule", r.Name(), "start", w.node.Class, "error", err)
-			} else {
-				for _, q := range queries {
-					if line := w.graph.FindLine(w.node.Class, q.Class(), r); line != nil {
-						log.V(4).Info("Rule applied", "line", line, "query", q)
-						w.outbox.Add(queryLine{Query: q, Line: line})
-					}
+			log.V(4).Info("Rule applied", "name", r.Name(), "start", w.node.Class, "error", err, "queries", len(queries))
+			for _, q := range queries {
+				if line := w.graph.FindLine(w.node.Class, q.Class(), r); line != nil {
+					log.V(5).Info("Add line", "line", line, "query", q)
+					w.outbox.Add(queryLine{Query: q, Line: line})
 				}
 			}
 		}

--- a/pkg/graph/data.go
+++ b/pkg/graph/data.go
@@ -59,9 +59,9 @@ func (d *Data) addClass(c korrel8r.Class) *Node {
 	}
 	id := int64(len(d.Nodes))
 	n := &Node{
-		Node:    multi.Node(id),
-		Class:   c,
-		Attrs:   Attrs{},
+		Node:         multi.Node(id),
+		Class:        c,
+		Attrs:        Attrs{},
 		Result:  result.New(c),
 		Queries: Queries{},
 	}
@@ -118,10 +118,10 @@ func (d *Data) Classes() []korrel8r.Class {
 // Node is a graph Node, contains a Class and search results.
 type Node struct {
 	multi.Node
-	Attrs   // GraphViz Attributer
-	Class   korrel8r.Class
+	Attrs        // GraphViz Attributer
+	Class        korrel8r.Class
 	Result  result.Result // Accumulate incoming query results.
-	Queries Queries       // All queries leading to this node.
+	Queries Queries      // All queries leading to this node.
 }
 
 func (n *Node) String(sorted bool) string {
@@ -144,20 +144,36 @@ func (n *Node) Empty() bool   { return len(n.Result.List()) == 0 }
 // QueryCount records count of objects resulting from a query.
 // Count == -1 means the query has not been evaluated.
 type QueryCount struct {
-	Query korrel8r.Query
-	Count int
+	Query        korrel8r.Query
+	Count        int
+	StatusCounts map[string]int
 }
 
 // Queries is a map of QueryCount by Query name.
 type Queries map[string]QueryCount
 
 func (qs Queries) Has(q korrel8r.Query) bool   { _, ok := qs[q.String()]; return ok }
-func (qs Queries) Set(q korrel8r.Query, n int) { qs[q.String()] = QueryCount{q, n} }
+func (qs Queries) Set(q korrel8r.Query, n int) {
+	qs[q.String()] = QueryCount{Query: q, Count: n}
+}
 func (qs Queries) Get(q korrel8r.Query) int {
 	if qc, ok := qs[q.String()]; ok {
 		return qc.Count
 	}
 	return -1
+}
+
+// AddStatuses merges status counts into the QueryCount for q.
+func (qs Queries) AddStatuses(q korrel8r.Query, statuses map[string]int) {
+	key := q.String()
+	qc := qs[key]
+	if qc.StatusCounts == nil {
+		qc.StatusCounts = map[string]int{}
+	}
+	for k, v := range statuses {
+		qc.StatusCounts[k] += v
+	}
+	qs[key] = qc
 }
 
 // Total of the counts

--- a/pkg/rest/helpers.go
+++ b/pkg/rest/helpers.go
@@ -34,7 +34,11 @@ func queryCounts(gq graph.Queries, _ api.GraphOptions) []api.QueryCount {
 		if qc.Count <= 0 {
 			continue // Omit query counts with no results
 		}
-		qcs = append(qcs, api.QueryCount{Query: qc.Query.String(), Count: &qc.Count})
+		aqc := api.QueryCount{Query: qc.Query.String(), Count: &qc.Count}
+		for k, v := range qc.StatusCounts {
+			aqc.Statuses = append(aqc.Statuses, api.StatusCount{Status: k, Count: ptr.To(v)})
+		}
+		qcs = append(qcs, aqc)
 	}
 	slices.SortFunc(qcs, func(a, b api.QueryCount) int {
 		if n := cmp.Compare(ptr.Deref(a.Count), ptr.Deref(b.Count)); n != 0 {

--- a/pkg/rest/rest_test.go
+++ b/pkg/rest/rest_test.go
@@ -220,6 +220,54 @@ func testEngine(t *testing.T) (e *engine.Engine) {
 
 func list[T any](x ...T) []T { return x }
 
+func TestAPIGraphGoals_labels(t *testing.T) {
+	d := mock.NewDomain("mock", "a", "b")
+	a, b := d.Class("a"), d.Class("b")
+	s := mock.NewStore(d)
+	s.AddQuery("mock:a:x", "ax")
+	s.AddQuery("mock:b:y", "by")
+	e, err := engine.Build().Domains(d).Stores(s).Rules(
+		mock.NewRule("a-b", list(a), list(b), mock.NewQuery(b, "y")),
+	).Config(config.Configs{
+		{
+			StatusRules: []config.StatusRule{
+				{
+					Name:   "label-b",
+					Start:  config.ClassSpec{Domain: "mock", Classes: []string{"b"}},
+					Result: config.LabelResultSpec{Labels: `my-label`},
+				},
+			},
+		},
+	}).Engine()
+	require.NoError(t, err)
+	assertDo(t, newTestAPI(t, e), "POST", "/api/v1alpha1/graphs/goals",
+		api.Goals{
+			Start: api.Start{
+				Class:   "mock:a",
+				Objects: []json.RawMessage{[]byte(`"x"`)},
+			},
+			Goals: []string{"mock:b"},
+		},
+		http.StatusOK,
+		api.Graph{
+			Nodes: []api.Node{
+				{
+					Class: "mock:a",
+					Count: ptr.To(1),
+				},
+				{
+					Class: "mock:b",
+					Count: ptr.To(1),
+					Queries: []api.QueryCount{{
+						Query:    "mock:b:y",
+						Count:    ptr.To(1),
+						Statuses: []api.StatusCount{{Status: "my-label", Count: ptr.To(1)}},
+					}},
+				}},
+			Edges: []api.Edge{{Start: "mock:a", Goal: "mock:b"}},
+		})
+}
+
 func TestAPIGraphNeighbors(t *testing.T) {
 	e := testEngine(t)
 	assertDo(t, newTestAPI(t, e), "POST", "/api/v1alpha1/graphs/neighbors",

--- a/pkg/status/rule.go
+++ b/pkg/status/rule.go
@@ -1,0 +1,52 @@
+// Copyright: This file is part of korrel8r, released under https://github.com/korrel8r/korrel8r/blob/main/LICENSE
+
+// Package status adds statuses to graph nodes.
+package status
+
+import (
+	"bytes"
+	"strings"
+	"text/template"
+
+	"github.com/korrel8r/korrel8r/pkg/korrel8r"
+)
+
+// Rule generates labels from an object.
+type Rule interface {
+	// Apply generates labels from a start object.
+	// Returns nil if the template produces only blank output.
+	Apply(start korrel8r.Object) ([]string, error)
+	// Start returns the classes this labeler applies to.
+	Start() []korrel8r.Class
+	// Name returns the labeler's name.
+	Name() string
+}
+
+type templateStatus struct {
+	tmpl  *template.Template
+	start []korrel8r.Class
+}
+
+// New returns a status Rule that uses a Go template to generate labels.
+func New(start []korrel8r.Class, tmpl *template.Template) Rule {
+	return &templateStatus{start: start, tmpl: tmpl}
+}
+
+func (l *templateStatus) Name() string            { return l.tmpl.Name() }
+func (l *templateStatus) Start() []korrel8r.Class { return l.start }
+
+func (l *templateStatus) Apply(start korrel8r.Object) ([]string, error) {
+	b := &bytes.Buffer{}
+	if err := l.tmpl.Execute(b, start); err != nil {
+		return nil, err
+	}
+	var statuses []string
+	for status := range strings.SplitSeq(b.String(), "\n") {
+		status = strings.TrimSpace(status)
+		if status == "" {
+			continue
+		}
+		statuses = append(statuses, status)
+	}
+	return statuses, nil
+}

--- a/pkg/status/rule_test.go
+++ b/pkg/status/rule_test.go
@@ -1,0 +1,75 @@
+// Copyright: This file is part of korrel8r, released under https://github.com/korrel8r/korrel8r/blob/main/LICENSE
+
+package status
+
+import (
+	"testing"
+	"text/template"
+
+	"github.com/korrel8r/korrel8r/internal/pkg/test/mock"
+	"github.com/korrel8r/korrel8r/pkg/korrel8r"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTemplateStatus_Apply(t *testing.T) {
+	d := mock.NewDomain("test", "foo")
+	c := d.Class("foo")
+
+	for _, tc := range []struct {
+		name     string
+		tmpl     string
+		obj      any
+		expected []string
+	}{
+		{
+			name:     "single status",
+			tmpl:     `hello`,
+			obj:      map[string]any{"x": 1},
+			expected: []string{"hello"},
+		},
+		{
+			name:     "multiple statuses",
+			tmpl:     "status1\nstatus2\nstatus3",
+			obj:      map[string]any{},
+			expected: []string{"status1", "status2", "status3"},
+		},
+		{
+			name:     "blank lines skipped",
+			tmpl:     "status1\n\n  \nstatus2\n",
+			obj:      map[string]any{},
+			expected: []string{"status1", "status2"},
+		},
+		{
+			name:     "all blank",
+			tmpl:     "\n  \n  \n",
+			obj:      map[string]any{},
+			expected: nil,
+		},
+		{
+			name:     "template with data",
+			tmpl:     `{{.name}}`,
+			obj:      map[string]any{"name": "my-status"},
+			expected: []string{"my-status"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpl := template.Must(template.New(tc.name).Parse(tc.tmpl))
+			lb := New([]korrel8r.Class{c}, tmpl)
+			assert.Equal(t, tc.name, lb.Name())
+			assert.Equal(t, []korrel8r.Class{c}, lb.Start())
+			statuses, err := lb.Apply(tc.obj)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, statuses)
+		})
+	}
+}
+
+func TestTemplateStatus_Apply_Error(t *testing.T) {
+	d := mock.NewDomain("test", "foo")
+	c := d.Class("foo")
+	tmpl := template.Must(template.New("err").Option("missingkey=error").Parse(`{{.missing}}`))
+	lb := New([]korrel8r.Class{c}, tmpl)
+	_, err := lb.Apply(map[string]any{})
+	assert.Error(t, err)
+}


### PR DESCRIPTION
A status rule generates a status string like "Warning" or "Error"

Initial rules included:
- HasFinalizer generates "Finalizer" status if an object has finalizers.
- EventType generates "Warning" for warning events.
- LogSeverity generates a status from log severity.
feat: add status rules to korrel8r nodes in graph results.

A status rule generates a status string like "Warning" or "Error"

Initial rules included:
- HasFinalizer generates "Finalizer" status if an object has finalizers.
- EventType generates "Warning" for warning events.
- LogSeverity generates a status from log severity.