### PR TITLE
fix: robust console connection, authentication and error handling

### DIFF
--- a/cmd/korrel8r/mcp.go
+++ b/cmd/korrel8r/mcp.go
@@ -23,7 +23,7 @@ For a HTTP streaming server use the 'web' command with the '--mcp' flag.
 	Run: func(cmd *cobra.Command, args []string) {
 		configs := must.Must1(config.Load(*configFlag))
 		e := must.Must1(newEngineWithConfigs(configs))
-		server := mcp.NewServer(session.NewSingle(e))
+		server := mcp.NewServer(session.NewSingleManager(e))
 		log.Info("MCP server starting on stdio.")
 		must.Must(server.ServeStdio(context.Background()))
 	},

--- a/cmd/korrel8r/web.go
+++ b/cmd/korrel8r/web.go
@@ -13,6 +13,7 @@ import (
 	"github.com/korrel8r/korrel8r/internal/pkg/build"
 	"github.com/korrel8r/korrel8r/internal/pkg/must"
 	"github.com/korrel8r/korrel8r/internal/pkg/tlsprofile"
+	"github.com/korrel8r/korrel8r/pkg/auth"
 	"github.com/korrel8r/korrel8r/pkg/config"
 	"github.com/korrel8r/korrel8r/pkg/engine"
 	"github.com/korrel8r/korrel8r/pkg/mcp"
@@ -61,16 +62,27 @@ var webCmd = &cobra.Command{
 			panic(fmt.Errorf("--tls-min-version, --tls-cipher-suites, and --tls-curves are not allowed with --http"))
 		}
 
-		// Use session timeout from initial configuration.
+		// Get session values from from top-level configuration
 		var timeout time.Duration
 		configs := must.Must1(config.Load(*configFlag))
 		if len(configs) > 0 && configs[0].Tuning != nil {
 			timeout = time.Duration(configs[0].Tuning.SessionTimeout)
+			if configs[0].Tuning.UnsafeSharedSession {
+				*unsafeSharedSessionFlag = true
+			}
 		}
-		sessions := session.NewPool(
-			timeout,
-			func() (*engine.Engine, error) { return newEngineWithConfigs(configs) },
-		)
+		var sessions session.Manager
+		if *unsafeSharedSessionFlag {
+			e := must.Must1(newEngineWithConfigs(configs))
+			sessions = session.NewSingleManager(e)
+		} else {
+			factory := func() (*engine.Engine, error) { return newEngineWithConfigs(configs) }
+			tokenReview, err := auth.NewTokenReview()
+			if err != nil {
+				panic(fmt.Errorf("cannot create token-based sessions: %w\nUse --unsafe-shared-session to run without authentication", err))
+			}
+			sessions = session.NewTokenReviewManager(tokenReview, timeout, factory)
+		}
 
 		gin.SetMode(gin.ReleaseMode)
 		router := gin.New()
@@ -101,15 +113,16 @@ var webCmd = &cobra.Command{
 }
 
 var (
-	httpFlag, httpsFlag *string
-	certFlag, keyFlag   *string
-	specFlag            *string
-	mcpFlag             *bool
-	restFlag            *bool
-	tlsMinVersionFlag   *string
-	tlsCipherSuitesFlag *[]string
-	tlsCurvesFlag       *[]string
-	WebProfile          func()
+	httpFlag, httpsFlag     *string
+	certFlag, keyFlag       *string
+	specFlag                *string
+	mcpFlag                 *bool
+	restFlag                *bool
+	unsafeSharedSessionFlag *bool
+	tlsMinVersionFlag       *string
+	tlsCipherSuitesFlag     *[]string
+	tlsCurvesFlag           *[]string
+	WebProfile              func()
 )
 
 func init() {
@@ -120,6 +133,7 @@ func init() {
 	keyFlag = webCmd.Flags().String("key", "", "Private key (PEM format) for https")
 	mcpFlag = webCmd.Flags().Bool("mcp", true, "Enable MCP streamable HTTP protocol on "+mcp.StreamablePath)
 	restFlag = webCmd.Flags().Bool("rest", true, "Enable HTTP REST server on "+rest.BasePath)
+	unsafeSharedSessionFlag = webCmd.Flags().Bool("unsafe-shared-session", false, "Allow unauthenticated requests to share a single session (UNSAFE: disables per-user isolation)")
 	specFlag = webCmd.Flags().String("spec", "", "Write OpenAPI specification to a file, '-' for stdout.")
 	tlsCipherSuitesFlag = webCmd.Flags().StringSlice("tls-cipher-suites", nil, "Comma-separated list of TLS cipher suites for https (IANA or OpenSSL names)")
 	tlsCurvesFlag = webCmd.Flags().StringSlice("tls-curves", nil, "Comma-separated list of TLS curves for https (Go or OpenSSL names, e.g. CurveP256/prime256v1, X25519)")

--- a/doc/gen/cmd/korrel8r_web.adoc
+++ b/doc/gen/cmd/korrel8r_web.adoc
@@ -20,6 +20,7 @@ korrel8r web [flags]
       --tls-cipher-suites strings   Comma-separated list of TLS cipher suites for https (IANA or OpenSSL names)
       --tls-curves strings          Comma-separated list of TLS curves for https (Go or OpenSSL names, e.g. CurveP256/prime256v1, X25519)
       --tls-min-version string      Minimum TLS version for https (e.g. VersionTLS12, VersionTLS13)
+      --unsafe-shared-session       Allow unauthenticated requests to share a single session (UNSAFE: disables per-user isolation)
 ----
 
 == Options inherited from parent commands

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/go-logr/stdr v1.2.2
 	github.com/go-openapi/runtime v0.29.3
 	github.com/go-openapi/strfmt v0.26.1
-	github.com/modelcontextprotocol/go-sdk v1.4.1
+	github.com/modelcontextprotocol/go-sdk v1.6.0
 	github.com/oapi-codegen/runtime v1.4.0
 	github.com/pkg/profile v1.7.0
 	github.com/prometheus/alertmanager v0.31.1
@@ -173,7 +173,7 @@ require (
 	github.com/golangci/unconvert v0.0.0-20250410112200-a129a6e6413e // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/google/jsonschema-go v0.4.2 // indirect
+	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/pprof v0.0.0-20260302011040-a15ffb7f9dcc // indirect
 	github.com/google/renameio/v2 v2.0.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -395,8 +395,8 @@ github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
-github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
+github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
+github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20211214055906-6f57359322fd/go.mod h1:KgnwoLYCZ8IQu3XUZ8Nc/bM9CCZFOyjUNOSygVozoDg=
 github.com/google/pprof v0.0.0-20240227163752-401108e1b7e7/go.mod h1:czg5+yv1E0ZGTi6S6vVK1mke0fV+FaUhNGcd6VRS9Ik=
@@ -545,8 +545,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/modelcontextprotocol/go-sdk v1.4.1 h1:M4x9GyIPj+HoIlHNGpK2hq5o3BFhC+78PkEaldQRphc=
-github.com/modelcontextprotocol/go-sdk v1.4.1/go.mod h1:Bo/mS87hPQqHSRkMv4dQq1XCu6zv4INdXnFZabkNU6s=
+github.com/modelcontextprotocol/go-sdk v1.6.0 h1:PPLS3kn7WtOEnR+Af4X5H96SG0qSab8R/ZQT/HkhPkY=
+github.com/modelcontextprotocol/go-sdk v1.6.0/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -118,6 +118,10 @@ type StatusRule struct {
 type Tuning struct {
 	// RequestTimeout cancels requests if they last longer than this timeout.
 	// If omitted or 0, requests never time out.
+	//
+	// This applies to all HTTP operations including long-lived SSE subscriptions,
+	// so it should be set generously as a safety net against resource exhaustion,
+	// not as a tight operational limit.
 	RequestTimeout Duration `json:"requestTimeout,omitempty"`
 
 	// SessionTimeout sets the idle timeout for sessions.
@@ -126,4 +130,8 @@ type Tuning struct {
 	// In server mode, the Authorization header of incoming REST or MCP requests identifies a session.
 	// Each session has a separate search engine, configuration and state.
 	SessionTimeout Duration `json:"sessionTimeout,omitempty"`
+
+	// UnsafeSharedSession skips authentication and uses a single shared session for all requests.
+	// WARNING: This disables per-user session isolation and should only be used for development or testing.
+	UnsafeSharedSession bool `json:"unsafeSharedSession,omitempty"`
 }

--- a/pkg/domains/alert/alert.go
+++ b/pkg/domains/alert/alert.go
@@ -250,7 +250,7 @@ func (s *Store) getLokiRulesForTenant(ctx context.Context, tenant string, namesp
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		log.V(1).Info("Loki ruler request returned non-OK status", "status", resp.StatusCode, "url", rulesURL.String())
+		log.V(5).Info("Loki ruler request returned non-OK status", "status", resp.StatusCode, "url", rulesURL.String())
 		return v1.RulesResult{}, fmt.Errorf("loki ruler request returned status %d", resp.StatusCode)
 	}
 

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -63,6 +63,12 @@ Korrel8r finds correlations between observability signals and resources in a Kub
 It connects data from different domains (logs, metrics, alerts, traces, Kubernetes resources, etc.)
 by following correlation rules to build a graph of related objects.
 
+## Console tools
+
+If the user refers to a console:
+- Use get_console to find out what data the user is looking at, in the form of a korrel8r query.
+- Use show_in_console to display results in the console. Express the results as a korrel8r query.
+
 ## Search tools
 
 1. Use list_domains to discover available domains.
@@ -73,14 +79,6 @@ by following correlation rules to build a graph of related objects.
    - Use create_neighbors_graph for open-ended exploration
      (e.g. "what is related to this pod?", "show me everything connected to these traces").
 
-## Console tools
-
-The user may have a graphical console that displays cluster data.
-If the user refers to a console:
-- Use get_console to find out what data the user is looking at, in the form of a korrel8r query.
-- Use show_in_console to display results in the console. Express the results as a korrel8r query.
-
-Console tools return an error if no console is connected, you can still use search tools.
 `
 
 const (
@@ -316,10 +314,12 @@ high-volume domains like logs, metrics, and traces.
 	mcp.AddTool(s.Server, &mcp.Tool{
 		Name: GetConsole,
 		Description: `
-Returns the current state of the user's graphical console (e.g. OpenShift web console).
+If the user refers to a console, use this tool to find out what the user is looking at.
 The result includes:
-- view: a query that selects the data displayed in the main console view. Not set if the console is displaying a view that does not support queries.
-- search: parameters for the correlation search displayed in the troubleshooting panel. Not set if the troubleshooting panel is not open.
+- view: a korrel8r query selecting data displayed in the main console view.
+  Not set if the console is not displaying data.
+- search: parameters for the correlation search displayed in the troubleshooting panel.
+  Not set if the troubleshooting panel is not open.
 
 Use view and search to understand what the user is looking at,
 and include it as context for further planning or actions.
@@ -330,9 +330,9 @@ and include it as context for further planning or actions.
 			if err != nil {
 				return nil, nil, err
 			}
-			state := ss.ConsoleState.Load()
+			state := ss.ConsoleState()
 			if state == nil {
-				return nil, nil, errors.New("not connected to console")
+				return nil, nil, errors.New("no console is connected")
 			}
 			return nil, state, nil
 		})
@@ -340,7 +340,7 @@ and include it as context for further planning or actions.
 	mcp.AddTool(s.Server, &mcp.Tool{
 		Name: ShowInConsole,
 		Description: `
-Update the user's graphical console to display new data to the user.
+If the user refers to a console, use this tool to update the console to display new data.
 
 - view: setting this field to a query updates the main view of the console to display the results of the query.
 - search: setting this field displays a correlation graph in the console troubleshooting panel.
@@ -348,21 +348,15 @@ Update the user's graphical console to display new data to the user.
 Use 'help' to learn the class and query syntax for each domain.
 `,
 	},
-		func(ctx context.Context, req *mcp.CallToolRequest, input ShowInConsoleParams) (*mcp.CallToolResult, any, error) {
+		func(ctx context.Context, req *mcp.CallToolRequest, update ShowInConsoleParams) (*mcp.CallToolResult, any, error) {
 			ss, err := s.session(ctx)
 			if err != nil {
-				return nil, nil, err // This is an internal error
+				return nil, nil, err
 			}
-			if err := rest.ConsoleOK(ss.Engine, &input); err != nil {
-				return errorResult(err), nil, err
+			if err := rest.ConsoleOK(ss.Engine, &update); err != nil {
+				return nil, nil, err
 			}
-			// Drain any stale request, then send the new one.
-			select {
-			case <-ss.ConsoleRequest:
-			default:
-			}
-			ss.ConsoleRequest <- &input
-			return nil, nil, nil
+			return nil, nil, ss.ShowInConsole(ctx, &update)
 		})
 }
 
@@ -401,27 +395,24 @@ func (s *Server) logger(handler mcp.MethodHandler) mcp.MethodHandler {
 					"tool", tool,
 					"latency", latency,
 					"parameters", logging.JSON(req.GetParams())}
-				if sn, _ := s.session(ctx); s != nil {
+				if sn, _ := s.session(ctx); sn != nil {
 					values = append(values, "session", sn.ID)
 				}
 				if err != nil {
-					log.V(3).Info("MCP error", append([]any{"error", err}, values...))
-				} else {
-					if log.V(9).Enabled() { // Result is extra detail
-						values = append(values, "result", logging.JSON(result))
-					}
-					log.V(3).Info("MCP call", values...)
+					log.V(3).Info("MCP error", append([]any{"error", err}, values...)...)
+					return
 				}
+				if r, ok := result.(*mcp.CallToolResult); ok && r.IsError {
+					log.V(3).Info("MCP error result", append(values, "result", logging.JSON(result))...)
+					return
+				}
+				if log.V(9).Enabled() {
+					values = append(values, "result", logging.JSON(result))
+				}
+				log.V(3).Info("MCP OK", values...)
 			}()
 		}
 		return handler(ctx, tool, req)
-	}
-}
-
-func errorResult(err error) *mcp.CallToolResult {
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}},
-		IsError: true,
 	}
 }
 

--- a/pkg/mcp/mcp_test.go
+++ b/pkg/mcp/mcp_test.go
@@ -26,6 +26,10 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
 )
 
 func TestListTools(t *testing.T) {
@@ -180,7 +184,7 @@ func newEngineMany(t *testing.T) *engine.Engine {
 func newClient(t *testing.T, e *engine.Engine) *mcp.ClientSession {
 	t.Helper()
 	ctx := context.Background()
-	s := NewServer(session.NewSingle(e))
+	s := NewServer(session.NewSingleManager(e))
 	ct, st := mcp.NewInMemoryTransports()
 	ss, err := s.Connect(ctx, st, nil)
 	require.NoError(t, err)
@@ -239,7 +243,7 @@ func newInteropFixture(t *testing.T, e *engine.Engine) *interopFixture {
 	if os.Getenv(gin.EnvGinMode) == "" {
 		gin.SetMode(gin.TestMode)
 	}
-	sessions := session.NewSingle(e)
+	sessions := session.NewSingleManager(e)
 	router := gin.New()
 	_, err := rest.New(sessions, router)
 	require.NoError(t, err)
@@ -512,10 +516,7 @@ func newMultiSessionFixture(t *testing.T) *multiSessionFixture {
 	if os.Getenv(gin.EnvGinMode) == "" {
 		gin.SetMode(gin.TestMode)
 	}
-	sessions := session.NewPool(time.Hour, func() (*engine.Engine, error) {
-		return newEngine(t), nil
-	})
-
+	sessions := session.NewTokenReviewManager(fakeTokenReview(), time.Hour, func() (*engine.Engine, error) { return newEngine(t), nil })
 	router := gin.New()
 	_, err := rest.New(sessions, router)
 	require.NoError(t, err)
@@ -671,4 +672,17 @@ func TestMultiSession_SSEIsolation(t *testing.T) {
 	case <-time.After(200 * time.Millisecond):
 		// expected
 	}
+}
+
+func fakeTokenReview() *auth.TokenReview {
+	cs := fake.NewSimpleClientset()
+	cs.PrependReactor("create", "tokenreviews", func(action ktesting.Action) (bool, runtime.Object, error) {
+		tr := action.(ktesting.CreateAction).GetObject().(*authenticationv1.TokenReview)
+		tr.Status = authenticationv1.TokenReviewStatus{
+			Authenticated: true,
+			User:          authenticationv1.UserInfo{Username: tr.Spec.Token},
+		}
+		return true, tr, nil
+	})
+	return auth.NewTokenReviewFromClientset(cs)
 }

--- a/pkg/rest/operations.go
+++ b/pkg/rest/operations.go
@@ -4,7 +4,9 @@
 package rest
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"slices"
@@ -231,52 +233,38 @@ func (a *API) SetConsole(c *gin.Context) {
 	if !check(c, http.StatusBadRequest, ConsoleOK(s.Engine, state)) {
 		return
 	}
-	s.ConsoleState.Store(state)
+	s.SetConsoleState(state)
 	c.JSON(http.StatusOK, state)
 }
 
 // SSE notification of console updates.
 // (GET /console/events)
 func (a *API) ConsoleEvents(c *gin.Context) {
-	// Set SSE headers
+	s, err := a.session(c)
+	if !check(c, http.StatusInternalServerError, err) {
+		return
+	}
+
 	w := c.Writer
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Allow-Headers", "Cache-Control")
-	w.Flush() // Send headers to start the SSE stream.
+	w.Flush()
 
-	s, err := a.session(c)
-	if !check(c, http.StatusInternalServerError, err) {
-		return
-	}
-	log := log // Don't modify main logger
-	if s.ID != "" {
-		log = log.WithValues("session", s)
-	}
+	log.V(3).Info("Console connected", "session", s)
+	defer log.V(3).Info("Console disconnected", "session", s)
+
 	keepAliveTicker := time.NewTicker(time.Minute)
 	defer keepAliveTicker.Stop()
-	log.V(3).Info("Console events started")
-	defer log.V(3).Info("Console events stopped")
-
-	for {
-		select {
-		case state := <-s.ConsoleRequest:
-			if !check(c, http.StatusInternalServerError, a.sendEvent(w, state)) {
-				return
-			}
-		case <-keepAliveTicker.C:
-			// Send a keep-alive comment
-			_, err = fmt.Fprint(w, ":keepalive\n\n")
-			if !check(c, http.StatusInternalServerError, err) {
-				return
-			}
-			w.Flush()
-
-		case <-c.Request.Context().Done():
-			return
-		}
+	err = s.ConsoleEvents(
+		c.Request.Context(),
+		func(c *api.Console) error { return a.sendEvent(w, c) },
+		func() error { _, err := fmt.Fprint(w, ":keepalive\n\n"); w.Flush(); return err },
+		keepAliveTicker)
+	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		log.V(3).Error(err, "Console send error", "session", s)
 	}
 }
 
@@ -288,7 +276,7 @@ func (a *API) sendEvent(w gin.ResponseWriter, update *api.Console) error {
 			return err
 		}
 		w.Flush()
-		log.V(3).Info("Console event sent", "event", string(b))
+		log.V(3).Info("Console update sent", "event", string(b))
 	}
 	return nil
 }

--- a/pkg/rest/rest_test.go
+++ b/pkg/rest/rest_test.go
@@ -159,7 +159,7 @@ type testAPI struct {
 
 func newTestAPI(t *testing.T, e *engine.Engine) *testAPI {
 	r := ginEngine()
-	a, err := New(session.NewSingle(e), r)
+	a, err := New(session.NewSingleManager(e), r)
 	require.NoError(t, err)
 	return &testAPI{API: a, Router: r}
 }
@@ -291,7 +291,7 @@ func TestAPIGraphNeighbors_badRequest(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-func TestMultiSession_QueryIsolation(t *testing.T) {
+func TestCluster_MultiSession_QueryIsolation(t *testing.T) {
 	// Each session gets a separate engine with different store data.
 	// Verify that REST requests with different auth tokens get different results.
 	var callCount atomic.Int32
@@ -302,7 +302,9 @@ func TestMultiSession_QueryIsolation(t *testing.T) {
 		s.AddQuery("mock:a:q", fmt.Sprintf("result-%d", n))
 		return engine.Build().Domains(d).Stores(s).Engine()
 	}
-	sessions := session.NewPool(time.Hour, factory)
+	tokenReview, err := auth.NewTokenReview()
+	require.NoError(t, err)
+	sessions := session.NewTokenReviewManager(tokenReview, time.Hour, factory)
 
 	r := ginEngine()
 	r.Use(func(c *gin.Context) {
@@ -310,7 +312,7 @@ func TestMultiSession_QueryIsolation(t *testing.T) {
 		c.Request = c.Request.WithContext(ctx)
 		c.Next()
 	})
-	_, err := New(sessions, r)
+	_, err = New(sessions, r)
 	require.NoError(t, err)
 
 	getObjects := func(token string) string {

--- a/pkg/session/console.go
+++ b/pkg/session/console.go
@@ -1,0 +1,104 @@
+// Copyright: This file is part of korrel8r, released under https://github.com/korrel8r/korrel8r/blob/main/LICENSE
+
+package session
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/korrel8r/korrel8r/pkg/api"
+)
+
+var NoConsoleErr = errors.New("no console is connected")
+
+// consoleEvents implements the MCP-to-REST and REST-to-MCP pathways through a session.
+type consoleEvents struct {
+	fromConsole atomic.Pointer[api.Console] // State from console, REST to MCP.
+	fromAgent   chan *api.Console           // Unbuffered: blocks MCP sender till console receives.
+
+	mu          sync.Mutex
+	cancel      context.CancelFunc // Cancel the current console listener.
+	listenerCtx context.Context    // Non-nil while a console listener is active.
+}
+
+func newConsoleEvents() *consoleEvents {
+	return &consoleEvents{
+		fromAgent: make(chan *api.Console),
+		cancel:    func() {},
+	}
+}
+
+// ShowInConsole sends an update to the console via the unbuffered fromAgent channel.
+// Blocks until the console receives the update or ctx is canceled.
+func (c *consoleEvents) ShowInConsole(ctx context.Context, update *api.Console) error {
+	for {
+		c.mu.Lock()
+		listenerCtx := c.listenerCtx
+		c.mu.Unlock()
+
+		if listenerCtx == nil {
+			return NoConsoleErr
+		}
+
+		select {
+		case c.fromAgent <- update:
+			return nil
+		case <-listenerCtx.Done():
+			// Listener may have been replaced — retry with fresh state.
+			continue
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// ConsoleEvents loops sending updates and keepalives until ctx is canceled or a send fails.
+// ctx should be the HTTP request context, which cancels on client disconnect.
+// Avoid passing a context with a short timeout — this is a long-lived SSE subscription.
+//
+// Only one listener is active at a time. A new caller evicts the previous listener
+// by canceling its context, so a stale connection cannot lock out new consoles.
+func (c *consoleEvents) ConsoleEvents(
+	ctx context.Context,
+	send func(*api.Console) error,
+	tick func() error,
+	ticker *time.Ticker) error {
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	func() {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		c.cancel()
+		c.cancel = cancel
+		c.listenerCtx = ctx
+	}()
+	defer func() {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		if c.listenerCtx == ctx {
+			c.fromConsole.Store(nil)
+			c.listenerCtx = nil
+		}
+	}()
+	for {
+		select {
+		case update := <-c.fromAgent:
+			if err := send(update); err != nil {
+				return err
+			}
+		case <-ticker.C:
+			if err := tick(); err != nil {
+				return err
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (c *consoleEvents) SetConsoleState(state *api.Console) { c.fromConsole.Store(state) }
+func (c *consoleEvents) ConsoleState() *api.Console         { return c.fromConsole.Load() }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -4,15 +4,13 @@
 // Each session has a numeric ID for logging and a string Key for map lookup.
 // Sessions expire after a configurable timeout of inactivity.
 //
-// Session key resolution follows this priority:
-//  1. Bearer token resolved via TokenReview to username
-//  2. Hashed Authorization header
+// Session key is the username resolved from a bearer token via TokenReview.
 package session
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/base64"
+	"errors"
+	"fmt"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -20,25 +18,24 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/korrel8r/korrel8r/internal/pkg/logging"
-	"github.com/korrel8r/korrel8r/pkg/api"
 	"github.com/korrel8r/korrel8r/pkg/auth"
 	"github.com/korrel8r/korrel8r/pkg/engine"
 )
 
 var log = logging.Log()
 
-// Console state, passes values between REST and MCP operations.
-type Console struct {
-}
+// AuthError wraps authentication errors so middleware can distinguish them from other session errors.
+type AuthError struct{ Err error }
+
+func (e *AuthError) Error() string { return e.Err.Error() }
+func (e *AuthError) Unwrap() error { return e.Err }
 
 // Session holds per-user state including engine, console state, and configuration.
 type Session struct {
-	ID             string // Session ID - a username or hashed authorization token.
-	Engine         *engine.Engine
-	ConsoleState   atomic.Pointer[api.Console]   // Current console state
-	ConsoleRequest chan *api.Console // Buffered channel, requested by agent.
-
+	ID       string // Session ID - a username or hashed authorization token.
+	Engine   *engine.Engine
 	lastUsed atomic.Int64 // UnixNano timestamp for expiration, atomic for lock-free access.
+	*consoleEvents
 }
 
 func (s *Session) String() string { return s.ID }
@@ -67,14 +64,15 @@ type singleManager struct {
 
 func newSession(e *engine.Engine, id string) *Session {
 	return &Session{
-		ID:             id,
-		Engine:         e,
-		ConsoleRequest: make(chan *api.Console, 1),
+		ID:            id,
+		Engine:        e,
+		consoleEvents: newConsoleEvents(),
 	}
 }
 
-// NewSingle returns a Manager that always returns the same session.
-func NewSingle(e *engine.Engine) Manager {
+// NewSingleManager returns a Manager that always returns the same session.
+// There is no session isolation.
+func NewSingleManager(e *engine.Engine) Manager {
 	return &singleManager{session: newSession(e, "")}
 }
 
@@ -100,49 +98,36 @@ type poolManager struct {
 	lastCleanup atomic.Int64
 }
 
-// NewPool creates a Manager that creates a new Session per key using factory
-// and expires sessions after timeout of inactivity.
-// timeout == 0 means never time out.
-// Automatically attempts to use k8s TokenReview for bearer token resolution.
-func NewPool(timeout time.Duration, factory func() (*engine.Engine, error)) Manager {
-	tokenReview, err := auth.NewTokenReview()
-	if err != nil {
-		log.V(1).Info("TokenReview not available, using hashed token as session ID", "error", err)
-	}
-	return NewPoolWithTokenReview(timeout, factory, tokenReview)
+// NewTokenReviewManager creates a Manager that creates per-user sessions
+// using bearer tokens and TokenReview to find the owning user-id.
+func NewTokenReviewManager(tokenReview *auth.TokenReview, timeout time.Duration, factory func() (*engine.Engine, error)) Manager {
+	return Manager(&poolManager{timeout: timeout, tokenReview: tokenReview, factory: factory})
 }
 
-// NewPoolWithTokenReview is like NewPool but uses the provided TokenReview
-// instead of creating one automatically. Pass nil to disable token resolution.
-func NewPoolWithTokenReview(timeout time.Duration, factory func() (*engine.Engine, error), tr *auth.TokenReview) Manager {
-	return &poolManager{
-		timeout:     timeout,
-		tokenReview: tr,
-		factory:     factory,
-	}
-}
-
-// id returns session ID for context
-func (m *poolManager) id(ctx context.Context) string {
-	token := auth.ContextToken(ctx)
-	if token == "" {
-		log.V(3).Info("No bearer token found, using generic session")
-		return ""
-	}
-	if m.tokenReview != nil {
-		userName, err := m.tokenReview.User(token)
-		if err == nil {
-			return userName
+func (m *poolManager) id(ctx context.Context) (id string, err error) {
+	defer func() {
+		if err != nil {
+			err = &AuthError{Err: fmt.Errorf("session authentication error: %w", err)}
 		}
-		log.V(3).Info("Token review error", "error", err)
+	}()
+	token := auth.ContextToken(ctx)
+	switch {
+	case token == "":
+		return "", errors.New("no bearer token in request")
+	case m.tokenReview == nil:
+		return "", errors.New("TokenReview is not available")
+	default:
+		return m.tokenReview.User(token)
 	}
-	log.V(3).Info("Cannot determine username, session ID is hashed token")
-	return hashToken(token)
 }
 
 // Get returns the Session for the given context, creating a new session if needed.
 func (m *poolManager) Get(ctx context.Context) (*Session, error) {
-	id := m.id(ctx)
+	id, err := m.id(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	v, _ := m.sessions.LoadOrStore(id, &entry{})
 	e := v.(*entry)
 	e.once.Do(func() {
@@ -189,11 +174,6 @@ func (m *poolManager) maybeCleanup(now int64) {
 	})
 }
 
-func hashToken(token string) string {
-	h := sha256.Sum256([]byte(token))
-	return base64.RawURLEncoding.EncodeToString(h[:])
-}
-
 type sessionKey struct{}
 
 // UpdateRequest adds session and timeout to request context.
@@ -217,7 +197,12 @@ func Middleware(sessions Manager) func(*gin.Context) {
 		c.Request = auth.UpdateRequest(c.Request)
 		req, cancel, err := UpdateRequest(c.Request, sessions)
 		if err != nil {
-			c.AbortWithStatusJSON(http.StatusInternalServerError, c.Error(err).JSON())
+			status := http.StatusInternalServerError
+			var authErr *AuthError
+			if errors.As(err, &authErr) {
+				status = http.StatusUnauthorized
+			}
+			c.AbortWithStatusJSON(status, c.Error(err).JSON())
 			return
 		}
 		defer cancel()

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -14,10 +14,31 @@ import (
 	"github.com/korrel8r/korrel8r/pkg/engine"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
 )
 
 func testFactory() (*engine.Engine, error) {
 	return engine.Build().Domains(mock.NewDomain("mock")).Engine()
+}
+
+func testMulti(timeout time.Duration) Manager {
+	return NewTokenReviewManager(fakeTokenReview(), timeout, testFactory)
+}
+
+func fakeTokenReview() *auth.TokenReview {
+	cs := fake.NewSimpleClientset()
+	cs.PrependReactor("create", "tokenreviews", func(action ktesting.Action) (bool, runtime.Object, error) {
+		tr := action.(ktesting.CreateAction).GetObject().(*authenticationv1.TokenReview)
+		tr.Status = authenticationv1.TokenReviewStatus{
+			Authenticated: true,
+			User:          authenticationv1.UserInfo{Username: tr.Spec.Token},
+		}
+		return true, tr, nil
+	})
+	return auth.NewTokenReviewFromClientset(cs)
 }
 
 func tokenCtx(token string) context.Context {
@@ -32,27 +53,21 @@ func getSession(t *testing.T, m Manager, token string) *Session {
 }
 
 func TestGet_SameKey(t *testing.T) {
-	m := NewPool(time.Hour, testFactory)
+	m := testMulti(time.Hour)
 	s1 := getSession(t, m, "key-a")
 	s2 := getSession(t, m, "key-a")
 	assert.Same(t, s1, s2, "same key should return same session")
 }
 
 func TestGet_DifferentKeys(t *testing.T) {
-	m := NewPool(time.Hour, testFactory)
+	m := testMulti(time.Hour)
 	s1 := getSession(t, m, "key-a")
 	s2 := getSession(t, m, "key-b")
 	assert.NotSame(t, s1, s2, "different keys should return different sessions")
 }
 
-func TestGet_HashedKey(t *testing.T) {
-	m := NewPool(time.Hour, testFactory)
-	s := getSession(t, m, "some-token")
-	assert.Equal(t, hashToken("some-token"), s.ID, "should use hashed token as key")
-}
-
 func TestConcurrent(t *testing.T) {
-	m := NewPool(time.Hour, testFactory)
+	m := testMulti(time.Hour)
 	var wg sync.WaitGroup
 	var count atomic.Int32
 	for range 100 {
@@ -68,7 +83,7 @@ func TestConcurrent(t *testing.T) {
 }
 
 func TestConcurrent_NewKey(t *testing.T) {
-	m := NewPool(time.Hour, testFactory)
+	m := testMulti(time.Hour)
 
 	// All goroutines race to create the same new key.
 	// They should all get the same session.
@@ -90,9 +105,28 @@ func TestConcurrent_NewKey(t *testing.T) {
 	}
 }
 
+func TestUnsafeSharedSession(t *testing.T) {
+	e, err := testFactory()
+	require.NoError(t, err)
+	m := NewSingleManager(e)
+
+	// No token — gets the shared session.
+	s1, err := m.Get(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "", s1.ID, "shared session should have empty ID")
+
+	// With tokens — still gets the same shared session.
+	s2, err := m.Get(tokenCtx("token-a"))
+	require.NoError(t, err)
+	s3, err := m.Get(tokenCtx("token-b"))
+	require.NoError(t, err)
+	assert.Same(t, s1, s2, "all requests should share the same session")
+	assert.Same(t, s1, s3, "all requests should share the same session")
+}
+
 func TestCleanup_OneExpiredOneActive(t *testing.T) {
 	timeout := 50 * time.Millisecond
-	m := NewPool(timeout, testFactory)
+	m := testMulti(timeout)
 
 	sOld := getSession(t, m, "old-token")
 

--- a/pkg/session/tokenreview_cluster_test.go
+++ b/pkg/session/tokenreview_cluster_test.go
@@ -4,7 +4,9 @@ package session
 
 import (
 	"testing"
+	"time"
 
+	"github.com/korrel8r/korrel8r/pkg/auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -15,16 +17,16 @@ func TestTokenReviewCluster_SessionID(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, cfg.BearerToken, "cluster config must have a bearer token")
 
-	m := NewPool(0, testFactory)
+	tr, err := auth.NewTokenReview()
+	require.NoError(t, err)
+	m := NewTokenReviewManager(tr, time.Hour, testFactory)
 
 	// Use the real bearer token to get a session.
 	ctx := tokenCtx(cfg.BearerToken)
 	s, err := m.Get(ctx)
 	require.NoError(t, err)
 
-	// Session ID should be the username, not a hash.
-	assert.NotEqual(t, hashToken(cfg.BearerToken), s.ID,
-		"with TokenReview available, session ID should be username, not hashed token")
+	assert.NotEmpty(t, s.ID, "session ID should be a username")
 	t.Logf("Session ID (username): %s", s.ID)
 
 	// Same token should return the same session.


### PR DESCRIPTION
Authentication safe: by default only allow username-authenticated sessions.
For dev/test, set "UnsafeSharedSession=true" for a single shared session.