### PR TITLE
fix: out-of-cluster server tests need --unsafe-shared-session

### DIFF
--- a/cmd/korrel8r/web.go
+++ b/cmd/korrel8r/web.go
@@ -79,7 +79,7 @@ var webCmd = &cobra.Command{
 			factory := func() (*engine.Engine, error) { return newEngineWithConfigs(configs) }
 			tokenReview, err := auth.NewTokenReview()
 			if err != nil {
-				panic(fmt.Errorf("cannot create token-based sessions: %w\nUse --unsafe-shared-session to run without authentication", err))
+				panic(fmt.Errorf("authentication unavailable: %w\nUse the --unsafe-shared-session flag if you want an unauthenticated server", err))
 			}
 			sessions = session.NewTokenReviewManager(tokenReview, timeout, factory)
 		}

--- a/cmd/korrel8r/web_test.go
+++ b/cmd/korrel8r/web_test.go
@@ -36,7 +36,7 @@ func startServer(t *testing.T, h *http.Client, scheme string, args ...string) *u
 	port, err := test.ListenPort()
 	require.NoError(t, err)
 	addr := net.JoinHostPort("localhost", strconv.Itoa(port))
-	cmd := command(t, append([]string{"web", "--" + scheme, addr}, args...)...)
+	cmd := command(t, append([]string{"web", "--" + scheme, addr, "--unsafe-shared-session"}, args...)...)
 	require.NoError(t, cmd.Start())
 	// Wait till server is available.
 	require.Eventually(t, func() bool {
@@ -135,7 +135,7 @@ func TestMain_server_tls_min_version(t *testing.T) {
 	port, err := test.ListenPort()
 	require.NoError(t, err)
 	addr := net.JoinHostPort("localhost", strconv.Itoa(port))
-	cmd := command(t, append([]string{"web", "--https", addr}, certArgs...)...)
+	cmd := command(t, append([]string{"web", "--https", addr, "--unsafe-shared-session"}, certArgs...)...)
 	require.NoError(t, cmd.Start())
 	t.Cleanup(func() { _ = cmd.Process.Kill() })
 


### PR DESCRIPTION
Sessions require token-based authentication to function safely.
The --unsafe-shared-session flag is for test/demo use to allow single-session server.