### PR TITLE
fix: fix duplicate middleware and sort status counts

### DIFF
--- a/pkg/rest/helpers.go
+++ b/pkg/rest/helpers.go
@@ -38,6 +38,7 @@ func queryCounts(gq graph.Queries, _ api.GraphOptions) []api.QueryCount {
 		for k, v := range qc.StatusCounts {
 			aqc.Statuses = append(aqc.Statuses, api.StatusCount{Status: k, Count: ptr.To(v)})
 		}
+		slices.SortFunc(aqc.Statuses, func(a, b api.StatusCount) int { return cmp.Compare(a.Status, b.Status) })
 		qcs = append(qcs, aqc)
 	}
 	slices.SortFunc(qcs, func(a, b api.QueryCount) int {
@@ -144,6 +145,9 @@ func Normalize(v any) any {
 		}
 	case []api.QueryCount:
 		slices.SortFunc(v, func(a, b api.QueryCount) int { return strings.Compare(a.Query, b.Query) })
+		for _, qc := range v {
+			slices.SortFunc(qc.Statuses, func(a, b api.StatusCount) int { return cmp.Compare(a.Status, b.Status) })
+		}
 	}
 	return v
 }

--- a/pkg/rest/operations.go
+++ b/pkg/rest/operations.go
@@ -50,7 +50,6 @@ func New(sessions session.Manager, r *gin.Engine) (*API, error) {
 		Sessions: sessions,
 		Router:   r,
 	}
-	r.Use(session.Middleware(sessions))
 	rg := r.Group(BasePath)
 	rg.Use(a.logger) // Apply logger only to API endpoints
 	RegisterHandlers(rg, a)

--- a/pkg/session/console.go
+++ b/pkg/session/console.go
@@ -33,6 +33,8 @@ func newConsoleEvents() *consoleEvents {
 
 // ShowInConsole sends an update to the console via the unbuffered fromAgent channel.
 // Blocks until the console receives the update or ctx is canceled.
+// The blocking is deliberate, it delays returning until we know the update was at least sent.
+// This tells the caller it was likely sent and processed, although it's not guaranteed.
 func (c *consoleEvents) ShowInConsole(ctx context.Context, update *api.Console) error {
 	for {
 		c.mu.Lock()


### PR DESCRIPTION
Remove duplicate session.Middleware that was applied both at the router
 level (web.go) and inside rest.New (operations.go), causing double
 authentication and timeout wrapping on every REST request.

 Sort StatusCounts deterministically by status name in queryCounts() and
 Normalize() to prevent non-deterministic API responses and flaky tests.