### PR TITLE
refactor: remove un-necessary cycle detection in traverse.go

### DIFF
--- a/pkg/engine/traverse/traverse.go
+++ b/pkg/engine/traverse/traverse.go
@@ -150,13 +150,9 @@ func (t *traverser) run(ctx context.Context, start Start, depth int) (*graph.Gra
 		busy.Wait() // Wait for worker.Run() goroutines to complete.
 
 		// Redistribute outboxes to inboxes. Not concurrent, touches all workers.
-		// Skip lines that would create cycles among visited nodes.
 		for _, w := range working {
 			for _, ql := range w.outbox {
 				if next := t.workers[ql.Query.Class()]; next != nil {
-					if t.createsCycle(w.node.ID(), next.node.ID()) {
-						continue
-					}
 					next.inbox.Add(ctx, ql)
 				}
 			}
@@ -242,34 +238,4 @@ func (w *worker) Run(ctx context.Context) {
 			}
 		}
 	}
-}
-
-// createsCycle returns true if adding an edge from→to would create a cycle.
-// BFS from 'to' through edges in t.graph, only following edges from nodes
-// that have results (i.e. nodes already visited during traversal).
-func (t *traverser) createsCycle(from, to int64) bool {
-	if from == to {
-		return true
-	}
-	visited := map[int64]bool{to: true}
-	queue := []int64{to}
-	for len(queue) > 0 {
-		curr := queue[0]
-		queue = queue[1:]
-		if t.graph.Node(curr).(*graph.Node).Empty() {
-			continue
-		}
-		succ := t.graph.From(curr)
-		for succ.Next() {
-			id := succ.Node().ID()
-			if id == from {
-				return true
-			}
-			if !visited[id] {
-				visited[id] = true
-				queue = append(queue, id)
-			}
-		}
-	}
-	return false
 }

--- a/pkg/engine/traverse/traverse_test.go
+++ b/pkg/engine/traverse/traverse_test.go
@@ -5,7 +5,9 @@ package traverse
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/korrel8r/korrel8r/internal/pkg/test/mock"
 	"github.com/korrel8r/korrel8r/pkg/engine"
@@ -131,8 +133,8 @@ func TestTraverserCycle(t *testing.T) {
 		start := Start{Class: b.Class("d:a"), Objects: []korrel8r.Object{0}}
 		g, err := Neighbors(context.Background(), e, start, 2)
 		require.NoError(t, err)
-		assert.ElementsMatch(t, []string{"ab(d:a->d:b)"}, g.LineStrings())
-		assert.ElementsMatch(t, []string{"d:a[0]", "d:b[1]"}, g.NodeStrings(true))
+		assert.ElementsMatch(t, []string{"ab(d:a->d:b)", "ba(d:b->d:a)"}, g.LineStrings())
+		assert.ElementsMatch(t, []string{"d:a[0,2]", "d:b[1]"}, g.NodeStrings(true))
 	})
 
 	t.Run("three_node_cycle", func(t *testing.T) {
@@ -148,8 +150,8 @@ func TestTraverserCycle(t *testing.T) {
 		start := Start{Class: b.Class("d:a"), Objects: []korrel8r.Object{0}}
 		g, err := Neighbors(context.Background(), e, start, 3)
 		require.NoError(t, err)
-		assert.ElementsMatch(t, []string{"ab(d:a->d:b)", "bc(d:b->d:c)"}, g.LineStrings())
-		assert.ElementsMatch(t, []string{"d:a[0]", "d:b[1]", "d:c[2]"}, g.NodeStrings(true))
+		assert.ElementsMatch(t, []string{"ab(d:a->d:b)", "bc(d:b->d:c)", "ca(d:c->d:a)"}, g.LineStrings())
+		assert.ElementsMatch(t, []string{"d:a[0,3]", "d:b[1]", "d:c[2]"}, g.NodeStrings(true))
 	})
 
 	t.Run("cycle_with_branch", func(t *testing.T) {
@@ -169,11 +171,60 @@ func TestTraverserCycle(t *testing.T) {
 		assert.ElementsMatch(t, []string{
 			"ab(d:a->d:b)",
 			"bc(d:b->d:c)",
+			"ca(d:c->d:a)",
 			"ad(d:a->d:d)",
 		}, g.LineStrings())
 		assert.ElementsMatch(t, []string{
-			"d:a[0]", "d:b[1]", "d:c[2]", "d:d[4]",
+			"d:a[0,3]", "d:b[1]", "d:c[2]", "d:d[4]",
 		}, g.NodeStrings(true))
+	})
+}
+
+// TestTraverserCycleUniqueQueries tests that cyclic rules generating unique queries
+// on every application (defeating query deduplication) do not cause infinite recursion.
+func TestTraverserCycleUniqueQueries(t *testing.T) {
+	b := mock.NewBuilder("d")
+	var counter atomic.Int64
+
+	// Each application generates a new unique query with a new unique object,
+	// so queryBox deduplication cannot stop the cycle.
+	uniqueRule := func(goalClass string) mock.ApplyFunc {
+		return func(start korrel8r.Object) ([]korrel8r.Query, error) {
+			n := counter.Add(1)
+			return []korrel8r.Query{
+				b.Query(goalClass, fmt.Sprintf("unique-%d", n), fmt.Sprintf("obj-%d", n)),
+			}, nil
+		}
+	}
+
+	e, err := engine.Build().Rules(
+		b.Rule("ab", "d:a", "d:b", uniqueRule("d:b")),
+		b.Rule("ba", "d:b", "d:a", uniqueRule("d:a")),
+	).Stores(b.Store("d", nil)).Engine()
+	require.NoError(t, err)
+
+	t.Run("Neighbors", func(t *testing.T) {
+		counter.Store(0)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		start := Start{Class: b.Class("d:a"), Objects: []korrel8r.Object{"start"}}
+		g, err := Neighbors(ctx, e, start, 5)
+		require.NoError(t, err, "should terminate at depth limit without context cancellation")
+		assert.NotEmpty(t, g.NodeStrings(true), "should have results")
+		t.Logf("nodes: %v", g.NodeStrings(true))
+		t.Logf("lines: %v", g.LineStrings())
+	})
+
+	t.Run("Goals", func(t *testing.T) {
+		counter.Store(0)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		start := Start{Class: b.Class("d:a"), Objects: []korrel8r.Object{"start"}}
+		g, err := Goals(ctx, e, start, []korrel8r.Class{b.Class("d:b")})
+		require.NoError(t, err, "should terminate without context cancellation")
+		assert.NotEmpty(t, g.NodeStrings(true), "should have results")
+		t.Logf("nodes: %v", g.NodeStrings(true))
+		t.Logf("lines: %v", g.LineStrings())
 	})
 }
 

--- a/pkg/graph/data.go
+++ b/pkg/graph/data.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"unique"
 
-	"github.com/korrel8r/korrel8r/internal/pkg/json"
 	"github.com/korrel8r/korrel8r/internal/pkg/cache"
+	"github.com/korrel8r/korrel8r/internal/pkg/json"
 	"github.com/korrel8r/korrel8r/pkg/korrel8r"
 	"github.com/korrel8r/korrel8r/pkg/result"
 	"gonum.org/v1/gonum/graph"
@@ -40,16 +40,14 @@ func NewData(rules ...korrel8r.Rule) *Data {
 func (d *Data) addRule(r korrel8r.Rule) {
 	for _, start := range r.Start() {
 		for _, goal := range r.Goal() {
-			if start != goal { // No circular rules.
-				id := int64(len(d.Lines))
-				l := &Line{
-					Line:    multi.Line{F: d.addClass(start), T: d.addClass(goal), UID: id},
-					Rule:    r,
-					Attrs:   Attrs{},
-					Queries: Queries{},
-				}
-				d.Lines = append(d.Lines, l)
+			id := int64(len(d.Lines))
+			l := &Line{
+				Line:    multi.Line{F: d.addClass(start), T: d.addClass(goal), UID: id},
+				Rule:    r,
+				Attrs:   Attrs{},
+				Queries: Queries{},
 			}
+			d.Lines = append(d.Lines, l)
 		}
 	}
 }


### PR DESCRIPTION
Not necessary because:
- Neighbors is bounded by depth, so no infinite cycles possible there.
- Goals uses k-shortest paths, which automatically filters out cycles.