### PR TITLE
fix: single console per session

### DIFF
--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -104,11 +104,18 @@ func NewServer(sessions session.Manager) *Server {
 	s := &Server{
 		Server: mcp.NewServer(
 			&mcp.Implementation{Name: "korrel8r", Title: "Korrel8r MCP Server", Version: build.Version},
-			&mcp.ServerOptions{Instructions: instructions}),
+			&mcp.ServerOptions{
+				Instructions:       instructions,
+				InitializedHandler: func(ctx context.Context, _ *mcp.InitializedRequest) {
+					if ss, err := sessions.Get(ctx); err == nil {
+						ss.EnqueueConsoleUpdate(&api.Console{})
+					}
+				},
+			}),
 		sessions: sessions,
 	}
 	s.addTools()
-	s.AddReceivingMiddleware(s.mcpInitNotifier, s.metrics, s.logger)
+	s.AddReceivingMiddleware(s.metrics, s.logger)
 	return s
 }
 
@@ -382,19 +389,6 @@ func (s *Server) session(ctx context.Context) (*session.Session, error) {
 // Per-session state is resolved per-request by tool handlers via sessions.Get.
 func (s *Server) handler(*http.Request) *mcp.Server {
 	return s.Server
-}
-
-// mcpInitNotifier is middleware that notifies the session when an MCP client connects.
-func (s *Server) mcpInitNotifier(handler mcp.MethodHandler) mcp.MethodHandler {
-	return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
-		result, err := handler(ctx, method, req)
-		if err == nil && method == "initialize" {
-			if ss, e := s.session(ctx); e == nil {
-				_ = ss.ShowInConsole(&api.Console{})
-			}
-		}
-		return result, err
-	}
 }
 
 // logger is middleware to do debug logging of MCP methods

--- a/pkg/mcp/mcp_test.go
+++ b/pkg/mcp/mcp_test.go
@@ -477,16 +477,6 @@ func TestInterop_ShowInConsoleToSSE(t *testing.T) {
 		_ = s.Err()
 	}()
 
-	// MCP client already connected in fixture — expect initial empty Console{}.
-	select {
-	case data := <-events:
-		var got api.Console
-		require.NoError(t, json.Unmarshal([]byte(data), &got))
-		assert.Equal(t, api.Console{}, got)
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for initial SSE event")
-	}
-
 	// Send console update via MCP show_in_console.
 	want := api.Console{View: "mock:a:x"}
 	r, err := f.mcp.CallTool(context.Background(), &mcp.CallToolParams{
@@ -496,7 +486,17 @@ func TestInterop_ShowInConsoleToSSE(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, r.IsError, "show_in_console should succeed")
 
-	// Verify the SSE event matches.
+	// First event is the empty MCP-connected signal.
+	select {
+	case data := <-events:
+		var got api.Console
+		require.NoError(t, json.Unmarshal([]byte(data), &got))
+		assert.Equal(t, api.Console{}, got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for MCP connection event")
+	}
+
+	// Second event is the actual update.
 	select {
 	case data := <-events:
 		var got api.Console
@@ -655,17 +655,6 @@ func TestMultiSession_SSEIsolation(t *testing.T) {
 
 	// MCP client for token-A sends a console update.
 	csA := f.mcpClient(t, "token-A")
-
-	// Session A receives the initial empty Console{} from MCP connect.
-	select {
-	case data := <-eventsA:
-		var got api.Console
-		require.NoError(t, json.Unmarshal([]byte(data), &got))
-		assert.Equal(t, api.Console{}, got)
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for initial SSE event on session A")
-	}
-
 	r, err := csA.CallTool(context.Background(), &mcp.CallToolParams{
 		Name:      ShowInConsole,
 		Arguments: ShowInConsoleParams{View: "mock:a:x"},
@@ -673,15 +662,16 @@ func TestMultiSession_SSEIsolation(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, r.IsError)
 
-	// Session A's SSE client should receive the update.
-	select {
-	case data := <-eventsA:
+	receive := func(events <-chan string) api.Console {
+		data := <-events
 		var got api.Console
 		require.NoError(t, json.Unmarshal([]byte(data), &got))
-		assert.Equal(t, "mock:a:x", got.View)
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for SSE event on session A")
+		return got
 	}
+	// MCP Connection event
+	assert.Equal(t, api.Console{}, receive(eventsA))
+	// Expected update.
+	assert.Equal(t, api.Console{View: "mock:a:x"}, receive(eventsA))
 
 	// Session B's SSE client should NOT receive anything.
 	select {
@@ -692,69 +682,39 @@ func TestMultiSession_SSEIsolation(t *testing.T) {
 	}
 }
 
-func TestInterop_SSEFanOut(t *testing.T) {
+func TestInterop_SSEBusy(t *testing.T) {
 	f := newInteropFixture(t, newEngine(t))
 
 	restSrv := httptest.NewServer(f.router)
 	t.Cleanup(restSrv.Close)
 
-	// Connect two SSE clients to the same session.
-	connectSSE := func() <-chan string {
-		ctx, cancel := context.WithCancel(context.Background())
-		t.Cleanup(cancel)
-		req, err := http.NewRequestWithContext(ctx, "GET", restSrv.URL+"/api/v1alpha1/console/events", nil)
-		require.NoError(t, err)
-		resp, err := http.DefaultClient.Do(req)
-		require.NoError(t, err)
-		t.Cleanup(func() { _ = resp.Body.Close() })
-
-		events := make(chan string, 10)
-		go func() {
-			defer close(events)
-			s := bufio.NewScanner(resp.Body)
-			for s.Scan() {
-				if data, ok := strings.CutPrefix(s.Text(), "data: "); ok {
-					events <- data
-				}
-			}
-			_ = s.Err()
-		}()
-		return events
-	}
-
-	eventsA := connectSSE()
-	eventsB := connectSSE()
-
-	// Both should receive the initial empty Console{} (MCP client already connected in fixture).
-	for _, events := range []<-chan string{eventsA, eventsB} {
-		select {
-		case data := <-events:
-			var got api.Console
-			require.NoError(t, json.Unmarshal([]byte(data), &got))
-			assert.Equal(t, api.Console{}, got)
-		case <-time.After(2 * time.Second):
-			t.Fatal("timed out waiting for initial SSE event")
-		}
-	}
-
-	// Send a console update via MCP.
-	want := api.Console{View: "mock:a:x"}
-	r, err := f.mcp.CallTool(context.Background(), &mcp.CallToolParams{
-		Name:      ShowInConsole,
-		Arguments: ShowInConsoleParams(want),
-	})
+	// First SSE connection should succeed.
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	t.Cleanup(cancel1)
+	req1, err := http.NewRequestWithContext(ctx1, "GET", restSrv.URL+"/api/v1alpha1/console/events", nil)
 	require.NoError(t, err)
-	require.False(t, r.IsError)
+	resp1, err := http.DefaultClient.Do(req1)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp1.Body.Close() })
+	require.Equal(t, http.StatusOK, resp1.StatusCode)
 
-	// Both SSE clients should receive the update.
-	for _, events := range []<-chan string{eventsA, eventsB} {
-		select {
-		case data := <-events:
-			var got api.Console
-			require.NoError(t, json.Unmarshal([]byte(data), &got))
-			assert.Equal(t, want, got)
-		case <-time.After(2 * time.Second):
-			t.Fatal("timed out waiting for SSE event")
-		}
-	}
+	// Second SSE connection to the same session should get 409 Conflict.
+	req2, err := http.NewRequest("GET", restSrv.URL+"/api/v1alpha1/console/events", nil)
+	require.NoError(t, err)
+	resp2, err := http.DefaultClient.Do(req2)
+	require.NoError(t, err)
+	defer func() { _ = resp2.Body.Close() }()
+	assert.Equal(t, http.StatusConflict, resp2.StatusCode)
+
+	// Close the first connection, then a new one should succeed.
+	cancel1()
+	_ = resp1.Body.Close()
+	time.Sleep(50 * time.Millisecond) // let the server-side handler return and clear the listener
+
+	req3, err := http.NewRequest("GET", restSrv.URL+"/api/v1alpha1/console/events", nil)
+	require.NoError(t, err)
+	resp3, err := http.DefaultClient.Do(req3)
+	require.NoError(t, err)
+	defer func() { _ = resp3.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp3.StatusCode)
 }

--- a/pkg/rest/helpers.go
+++ b/pkg/rest/helpers.go
@@ -36,7 +36,7 @@ func queryCounts(gq graph.Queries, _ api.GraphOptions) []api.QueryCount {
 		}
 		aqc := api.QueryCount{Query: qc.Query.String(), Count: &qc.Count}
 		for k, v := range qc.StatusCounts {
-			aqc.Statuses = append(aqc.Statuses, api.StatusCount{Status: k, Count: ptr.To(v)})
+			aqc.Statuses = append(aqc.Statuses, api.StatusCount{Status: k, Count: new(v)})
 		}
 		slices.SortFunc(aqc.Statuses, func(a, b api.StatusCount) int { return cmp.Compare(a.Status, b.Status) })
 		qcs = append(qcs, aqc)
@@ -60,7 +60,7 @@ func node(n *graph.Node, opts api.GraphOptions) api.Node {
 	node := api.Node{
 		Class:   n.Class.String(),
 		Queries: queryCounts(n.Queries, opts),
-		Count:   ptr.To(len(n.Result.List())),
+		Count:   new(len(n.Result.List())),
 	}
 	if ptr.Deref(opts.Results) {
 		for _, o := range n.Result.List() {

--- a/pkg/rest/logger.go
+++ b/pkg/rest/logger.go
@@ -13,26 +13,34 @@ func (a *API) logger(c *gin.Context) {
 	if !log.V(2).Enabled() {
 		return // Nothing to do for V < 2
 	}
-	var rw *responseWriter
-	if log.V(9).Enabled() {
-		rw = newResponseWriter(c.Writer) // Save the response
-		c.Writer = rw
-	}
+
 	start := time.Now()
+	detail := log.V(9).Enabled() // Extra detail
+
+	values := []any{
+		"method", c.Request.Method,
+		"url", c.Request.URL,
+	}
+	var rw *responseWriter
+	if detail {
+		rw = newResponseWriter(c.Writer)
+		c.Writer = rw // Save the response
+		values = append(values,
+			"from", c.Request.RemoteAddr,
+			"body", copyBody(c.Request),
+		)
+	}
+
+	log.V(3).Info("REST Request", values...)
 
 	defer func() {
-		latency := time.Since(start)
-		status := c.Writer.Status()
-		values := []any{
-			"method", c.Request.Method,
-			"url", c.Request.URL,
-			"status", status,
-			"latency", latency,
-		}
-		if rw != nil { // Response was saved, extra detail
+		values = append(values,
+			"status", c.Writer.Status(),
+			"latency", time.Since(start),
+		)
+		if detail {
 			values = append(values,
-				"from", c.Request.RemoteAddr,
-				"body", copyBody(c.Request),
+				"request", copyBody(c.Request),
 				"response", rw.String(),
 			)
 		}
@@ -40,9 +48,9 @@ func (a *API) logger(c *gin.Context) {
 			values = append(values, "errors", c.Errors.Errors())
 		}
 		if c.IsAborted() || c.Writer.Status()/100 != 2 {
-			log.V(2).Info("Request failed", values...)
+			log.V(2).Info("REST Request failed", values...)
 		} else {
-			log.V(3).Info("Request OK", values...)
+			log.V(3).Info("REST Request OK", values...)
 		}
 	}()
 	c.Next()

--- a/pkg/rest/operations.go
+++ b/pkg/rest/operations.go
@@ -245,6 +245,11 @@ func (a *API) ConsoleEvents(c *gin.Context) {
 		return
 	}
 
+	if !check(c, http.StatusConflict, s.SetListener()) {
+		return
+	}
+	defer s.ClearListener()
+
 	w := c.Writer
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
@@ -253,17 +258,15 @@ func (a *API) ConsoleEvents(c *gin.Context) {
 	w.Header().Set("Access-Control-Allow-Headers", "Cache-Control")
 	w.Flush()
 
-	log.V(3).Info("Console connected", "session", s)
-	defer log.V(3).Info("Console disconnected", "session", s)
-
-	// SSE is long-lived — use a context that detects HTTP client disconnect
-	// but is not subject to the request timeout.
-	ctx, cancel := context.WithCancel(context.Background())
+	// Strip the middleware's request timeout — SSE is long-lived.
+	// context.WithoutCancel preserves values but detaches from the deadline,
+	// then AfterFunc re-attaches disconnect detection from the parent.
+	ctx, cancel := context.WithCancel(context.WithoutCancel(c.Request.Context()))
 	defer cancel()
 	stop := context.AfterFunc(c.Request.Context(), cancel)
 	defer stop()
 
-	keepAliveTicker := time.NewTicker(time.Minute)
+	keepAliveTicker := time.NewTicker(3 * time.Second)
 	defer keepAliveTicker.Stop()
 	err = s.ConsoleEvents(
 		ctx,
@@ -271,7 +274,7 @@ func (a *API) ConsoleEvents(c *gin.Context) {
 		func() error { _, err := fmt.Fprint(w, ":keepalive\n\n"); w.Flush(); return err },
 		keepAliveTicker)
 	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-		log.V(3).Error(err, "Console send error", "session", s)
+		log.V(3).Error(err, "Console SSE error", "session", s)
 	}
 }
 

--- a/pkg/session/console.go
+++ b/pkg/session/console.go
@@ -5,99 +5,103 @@ package session
 import (
 	"context"
 	"errors"
-	"slices"
-	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/korrel8r/korrel8r/pkg/api"
+	"github.com/korrel8r/korrel8r/internal/pkg/logging"
 )
 
-var ErrNoConsole = errors.New("no console is connected")
-
-type consoleListener struct {
-	ch chan *api.Console
-}
+var (
+	ErrNoConsole   = errors.New("no console is connected")
+	ErrConsoleBusy = errors.New("another console is already connected to this session")
+)
 
 // consoleEvents implements the MCP-to-REST and REST-to-MCP pathways through a session.
-// Multiple console SSE listeners can be active simultaneously; ShowInConsole fans out to all.
+// Only one console SSE listener can be active per session.
 type consoleEvents struct {
-	fromConsole  atomic.Pointer[api.Console] // State from console, REST to MCP.
-	mcpConnected bool                        // True after an MCP client has connected. Protected by mu.
-
-	mu        sync.Mutex
-	listeners []*consoleListener
+	session      string
+	fromConsole  atomic.Pointer[api.Console] // Latest state from console (REST→MCP).
+	update       chan *api.Console           // Latest-value channel for console updates (MCP→REST).
+	connected    atomic.Bool                 // True while an SSE listener is connected.
+	mcpConnected atomic.Bool                 // True once any MCP client has connected; survives listener reconnects.
 }
 
-func newConsoleEvents() *consoleEvents {
-	return &consoleEvents{}
-}
-
-// addListener registers a new SSE listener.
-// Returns true if an MCP client is already connected.
-func (c *consoleEvents) addListener() (*consoleListener, bool) {
-	l := &consoleListener{ch: make(chan *api.Console, 1)}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.listeners = append(c.listeners, l)
-	return l, c.mcpConnected
-}
-
-func (c *consoleEvents) removeListener(l *consoleListener) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.listeners = slices.DeleteFunc(c.listeners, func(x *consoleListener) bool { return x == l })
-	if len(c.listeners) == 0 {
-		c.fromConsole.Store(nil)
+func newConsoleEvents(session string) *consoleEvents {
+	return &consoleEvents{
+		session: session,
+		update:  make(chan *api.Console, 1),
 	}
 }
 
-// ShowInConsole sends an update to all connected console SSE listeners.
-// Any previously unsent value is replaced with the new one.
-// Records that an MCP client is connected, so late-joining listeners
-// receive an initial notification.
-// Returns ErrNoConsole if no listeners are connected.
-func (c *consoleEvents) ShowInConsole(update *api.Console) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.mcpConnected = true
-	if len(c.listeners) == 0 {
-		return ErrNoConsole
-	}
-	for _, l := range c.listeners {
-		select {
-		case <-l.ch:
-		default:
-		}
-		l.ch <- update
+// SetListener registers the SSE listener for this session.
+// Returns ErrConsoleBusy if a listener is already connected.
+// The caller must call ClearListener when done.
+func (c *consoleEvents) SetListener() error {
+	if !c.connected.CompareAndSwap(false, true) {
+		return ErrConsoleBusy
 	}
 	return nil
+}
+
+// ClearListener removes the active SSE listener and drains pending updates.
+func (c *consoleEvents) ClearListener() {
+	c.connected.Store(false)
+	c.fromConsole.Store(nil)
+	select {
+	case <-c.update:
+	default:
+	}
+}
+
+// ShowInConsole enqueues an update for the console SSE listener.
+// Returns ErrNoConsole if no listener is connected.
+// The latest value wins: any stale pending update is replaced.
+func (c *consoleEvents) ShowInConsole(update *api.Console) error {
+	if !c.connected.Load() {
+		return ErrNoConsole
+	}
+	c.EnqueueConsoleUpdate(update)
+	return nil
+}
+
+// EnqueueConsoleUpdate enqueues an update without requiring a connected listener.
+// Use this for signals (like MCP connection) that may arrive before the SSE listener starts.
+func (c *consoleEvents) EnqueueConsoleUpdate(update *api.Console) {
+	c.mcpConnected.Store(true)
+	select {
+	case <-c.update:
+	default:
+	}
+	c.update <- update
+	log.V(3).Info("Console: enqueue", "session", c.session, "update", logging.JSON(update))
 }
 
 // ConsoleEvents loops sending updates and keepalives until ctx is canceled or a send fails.
 // ctx should be the HTTP request context, which cancels on client disconnect.
 // Avoid passing a context with a short timeout — this is a long-lived SSE subscription.
 //
-// Multiple listeners can be active simultaneously; each receives all updates.
+// The caller must call SetListener before this and ClearListener after.
 func (c *consoleEvents) ConsoleEvents(
 	ctx context.Context,
 	send func(*api.Console) error,
 	tick func() error,
 	ticker *time.Ticker) error {
 
-	l, connected := c.addListener()
-	defer c.removeListener(l)
+	consoleSend := func(update *api.Console) error {
+		log.V(3).Info("Console: send", "session", c.session, "update", logging.JSON(update))
+		return send(update)
+	}
 
-	if connected {
-		if err := send(&api.Console{}); err != nil {
+	if c.mcpConnected.Load() {
+		if err := consoleSend(&api.Console{}); err != nil {
 			return err
 		}
 	}
-
 	for {
 		select {
-		case update := <-l.ch:
-			if err := send(update); err != nil {
+		case update := <-c.update:
+			if err := consoleSend(update); err != nil {
 				return err
 			}
 		case <-ticker.C:

--- a/pkg/session/console_test.go
+++ b/pkg/session/console_test.go
@@ -1,0 +1,269 @@
+// Copyright: This file is part of korrel8r, released under https://github.com/korrel8r/korrel8r/blob/main/LICENSE
+
+package session
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/korrel8r/korrel8r/pkg/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func console(view string) *api.Console { return &api.Console{View: api.Query(view)} }
+
+func TestSetListener_Busy(t *testing.T) {
+	c := newConsoleEvents("test")
+	require.NoError(t, c.SetListener())
+	defer c.ClearListener()
+	assert.ErrorIs(t, c.SetListener(), ErrConsoleBusy)
+}
+
+func TestSetListener_Reuse(t *testing.T) {
+	c := newConsoleEvents("test")
+	require.NoError(t, c.SetListener())
+	c.ClearListener()
+	require.NoError(t, c.SetListener())
+	c.ClearListener()
+}
+
+func TestShowInConsole_NoListener(t *testing.T) {
+	c := newConsoleEvents("test")
+	assert.ErrorIs(t, c.ShowInConsole(console("v1")), ErrNoConsole)
+}
+
+func TestShowInConsole_Send(t *testing.T) {
+	c := newConsoleEvents("test")
+	require.NoError(t, c.SetListener())
+	defer c.ClearListener()
+	require.NoError(t, c.ShowInConsole(console("v1")))
+	select {
+	case got := <-c.update:
+		assert.Equal(t, console("v1"), got)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for update")
+	}
+}
+
+func TestShowInConsole_LatestValueWins(t *testing.T) {
+	c := newConsoleEvents("test")
+	require.NoError(t, c.SetListener())
+	defer c.ClearListener()
+	require.NoError(t, c.ShowInConsole(console("v1")))
+	require.NoError(t, c.ShowInConsole(console("v2")))
+	select {
+	case got := <-c.update:
+		assert.Equal(t, console("v2"), got)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for update")
+	}
+}
+
+func TestClearListener_DrainsPending(t *testing.T) {
+	c := newConsoleEvents("test")
+	require.NoError(t, c.SetListener())
+	require.NoError(t, c.ShowInConsole(console("v1")))
+	c.ClearListener()
+	select {
+	case <-c.update:
+		t.Fatal("expected channel to be drained")
+	default:
+	}
+}
+
+func TestConsoleState(t *testing.T) {
+	c := newConsoleEvents("test")
+	assert.Nil(t, c.ConsoleState())
+	c.SetConsoleState(console("state1"))
+	assert.Equal(t, console("state1"), c.ConsoleState())
+}
+
+func TestClearListener_ResetsConsoleState(t *testing.T) {
+	c := newConsoleEvents("test")
+	require.NoError(t, c.SetListener())
+	c.SetConsoleState(console("state1"))
+	c.ClearListener()
+	assert.Nil(t, c.ConsoleState())
+}
+
+func TestConsoleEvents_SendsUpdates(t *testing.T) {
+	c := newConsoleEvents("test")
+	require.NoError(t, c.SetListener())
+	defer c.ClearListener()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var received []*api.Console
+	send := func(u *api.Console) error {
+		received = append(received, u)
+		if len(received) == 3 {
+			cancel()
+		}
+		return nil
+	}
+	ticker := time.NewTicker(time.Hour)
+	defer ticker.Stop()
+
+	// ShowInConsole sets mcpConnected, so pre-loop check sends empty first.
+	require.NoError(t, c.ShowInConsole(console("v1")))
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		require.NoError(t, c.ShowInConsole(console("v2")))
+	}()
+
+	err := c.ConsoleEvents(ctx, send, func() error { return nil }, ticker)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, []*api.Console{{}, console("v1"), console("v2")}, received)
+}
+
+func TestConsoleEvents_MCPConnectsFirst(t *testing.T) {
+	c := newConsoleEvents("test")
+
+	// MCP connects before the SSE listener — empty event waits in the channel.
+	c.EnqueueConsoleUpdate(&api.Console{})
+
+	require.NoError(t, c.SetListener())
+	defer c.ClearListener()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var received []*api.Console
+	send := func(u *api.Console) error {
+		received = append(received, u)
+		if len(received) == 2 {
+			cancel()
+		}
+		return nil
+	}
+	ticker := time.NewTicker(time.Hour)
+	defer ticker.Stop()
+
+	err := c.ConsoleEvents(ctx, send, func() error { return nil }, ticker)
+	assert.ErrorIs(t, err, context.Canceled)
+	// Pre-loop empty (mcpConnected flag), then queued empty from EnqueueConsoleUpdate.
+	assert.Equal(t, []*api.Console{{}, {}}, received)
+}
+
+func TestConsoleEvents_MCPConnectsLater(t *testing.T) {
+	c := newConsoleEvents("test")
+	require.NoError(t, c.SetListener())
+	defer c.ClearListener()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var received []*api.Console
+	send := func(u *api.Console) error {
+		received = append(received, u)
+		cancel()
+		return nil
+	}
+	ticker := time.NewTicker(time.Hour)
+	defer ticker.Stop()
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		require.NoError(t, c.ShowInConsole(console("v1")))
+	}()
+
+	err := c.ConsoleEvents(ctx, send, func() error { return nil }, ticker)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, []*api.Console{console("v1")}, received)
+}
+
+func TestConsoleEvents_MCPEmptyThenUpdate(t *testing.T) {
+	c := newConsoleEvents("test")
+	require.NoError(t, c.SetListener())
+	defer c.ClearListener()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var received []*api.Console
+	send := func(u *api.Console) error {
+		received = append(received, u)
+		if len(received) == 3 {
+			cancel()
+		}
+		return nil
+	}
+	ticker := time.NewTicker(time.Hour)
+	defer ticker.Stop()
+
+	// Simulate MCP initialized then tool call.
+	require.NoError(t, c.ShowInConsole(&api.Console{}))
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		require.NoError(t, c.ShowInConsole(console("v1")))
+	}()
+
+	err := c.ConsoleEvents(ctx, send, func() error { return nil }, ticker)
+	assert.ErrorIs(t, err, context.Canceled)
+	// Pre-loop empty (mcpConnected), then queued empty, then v1.
+	assert.Equal(t, []*api.Console{{}, {}, console("v1")}, received)
+}
+
+func TestConsoleEvents_ReconnectGetsMCPSignal(t *testing.T) {
+	c := newConsoleEvents("test")
+	require.NoError(t, c.SetListener())
+
+	// MCP connects, event is consumed by the loop.
+	c.EnqueueConsoleUpdate(&api.Console{})
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel1()
+	}()
+	_ = c.ConsoleEvents(ctx1, func(*api.Console) error { return nil }, func() error { return nil }, time.NewTicker(time.Hour))
+	c.ClearListener()
+
+	// New listener reconnects — should get empty signal from mcpConnected flag.
+	require.NoError(t, c.SetListener())
+	defer c.ClearListener()
+
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+
+	var received []*api.Console
+	send := func(u *api.Console) error {
+		received = append(received, u)
+		cancel2()
+		return nil
+	}
+	ticker := time.NewTicker(time.Hour)
+	defer ticker.Stop()
+
+	err := c.ConsoleEvents(ctx2, send, func() error { return nil }, ticker)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, []*api.Console{{}}, received)
+}
+
+func TestConsoleEvents_Tick(t *testing.T) {
+	c := newConsoleEvents("test")
+	require.NoError(t, c.SetListener())
+	defer c.ClearListener()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tickCount := 0
+	tick := func() error {
+		tickCount++
+		if tickCount >= 2 {
+			cancel()
+		}
+		return nil
+	}
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	err := c.ConsoleEvents(ctx, func(*api.Console) error { return nil }, tick, ticker)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.GreaterOrEqual(t, tickCount, 2)
+}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -66,7 +66,7 @@ func newSession(e *engine.Engine, id string) *Session {
 	return &Session{
 		ID:            id,
 		Engine:        e,
-		consoleEvents: newConsoleEvents(),
+		consoleEvents: newConsoleEvents(id),
 	}
 }
 
@@ -198,8 +198,7 @@ func Middleware(sessions Manager) func(*gin.Context) {
 		req, cancel, err := UpdateRequest(c.Request, sessions)
 		if err != nil {
 			status := http.StatusInternalServerError
-			var authErr *AuthError
-			if errors.As(err, &authErr) {
+			if _, ok := errors.AsType[*AuthError](err); ok {
 				status = http.StatusUnauthorized
 			}
 			c.AbortWithStatusJSON(status, c.Error(err).JSON())

--- a/pkg/session/tokenreview_cluster_test.go
+++ b/pkg/session/tokenreview_cluster_test.go
@@ -27,7 +27,6 @@ func TestTokenReviewCluster_SessionID(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, s.ID, "session ID should be a username")
-	t.Logf("Session ID (username): %s", s.ID)
 
 	// Same token should return the same session.
 	s2, err := m.Get(tokenCtx(cfg.BearerToken))


### PR DESCRIPTION
Multiple consoles to a session does not work without some more detailed session ID.
Restrict to a single console per session for now with clear error message.

NOTE: we still support multiple *users*, just not multiple *consoles per user*.