### PR TITLE
feat(rules): add KubeVirt correlation rules for VM troubleshooting

### DIFF
--- a/etc/korrel8r/rules/all.yaml
+++ b/etc/korrel8r/rules/all.yaml
@@ -5,3 +5,4 @@ include:
   - netflow.yaml
   - trace.yaml
   - incident.yaml
+  - kubevirt.yaml

--- a/etc/korrel8r/rules/k8s.yaml
+++ b/etc/korrel8r/rules/k8s.yaml
@@ -120,17 +120,6 @@ rules:
       query: |-
         k8s:Node:{"name":"{{.spec.nodeName}}"}
 
-  - name: VmiToNode
-    start:
-      domain: k8s
-      classes: [VirtualMachineInstance.kubevirt.io]
-    goal:
-      domain: k8s
-      classes: [Node]
-    result:
-      query: |-
-        k8s:Node:{"name":"{{.status.nodeName}}"}
-
   - name: VolumeAttachmentToNode
     start:
       domain: k8s
@@ -170,19 +159,6 @@ rules:
         k8s:Node:{"name":"{{.}}"}
         {{- end}}
 
-  - name: VmToPVC
-    start:
-      domain: k8s
-      classes: [VirtualMachine.kubevirt.io]
-    goal:
-      domain: k8s
-      classes: [PersistentVolumeClaim]
-    result:
-      query: |-
-        {{- range .spec.dataVolumeTemplates }}
-        k8s:PersistentVolumeClaim:{"namespace":"{{$.metadata.namespace}}","name":"{{.metadata.name}}"}
-        {{- end }}
-
   - name: PVCToPV
     start:
       domain: k8s
@@ -215,28 +191,6 @@ rules:
     result:
       query: |-
         k8s:StorageClass.storage.k8s.io:{"name":"{{.spec.storageClassName}}"}
-
-  - name: VmToVmi
-    start:
-      domain: k8s
-      classes: [VirtualMachine.kubevirt.io]
-    goal:
-      domain: k8s
-      classes: [VirtualMachineInstance.kubevirt.io]
-    result:
-      query: |-
-        k8s:VirtualMachineInstance.kubevirt.io:{"namespace":"{{.metadata.namespace}}","name":"{{.metadata.name}}"}
-
-  - name: VmiToPod
-    start:
-      domain: k8s
-      classes: [VirtualMachineInstance.kubevirt.io]
-    goal:
-      domain: k8s
-      classes: [Pod]
-    result:
-      query: |-
-        k8s:Pod:{"namespace":"{{.metadata.namespace}}","labels":{"vm.kubevirt.io/name":"{{.metadata.name}}","kubevirt.io":"virt-launcher"}}
 
   - name: SubscriptionToCSV
     start:

--- a/etc/korrel8r/rules/k8s_test.go
+++ b/etc/korrel8r/rules/k8s_test.go
@@ -116,30 +116,6 @@ func TestK8sRules(t *testing.T) {
 			want: []string{`k8s:PersistentVolume.v1:{"name":"owner"}`},
 		},
 		{
-			rule: "VmiToNode",
-			start: newK8s("VirtualMachineInstance.kubevirt.io", "vm-ns", "vm-name", k8s.Object{
-				"status": k8s.Object{
-					"nodeName": "worker-1",
-				},
-			}),
-			want: []string{`k8s:Node.v1:{"name":"worker-1"}`},
-		},
-		{
-			rule: "VmToPVC",
-			start: newK8s("VirtualMachine.kubevirt.io", "vm-ns", "vm-name", k8s.Object{
-				"spec": k8s.Object{
-					"dataVolumeTemplates": []k8s.Object{
-						{"metadata": k8s.Object{"name": "dv1"}},
-						{"metadata": k8s.Object{"name": "dv2"}},
-					},
-				},
-			}),
-			want: []string{
-				`k8s:PersistentVolumeClaim.v1:{"namespace":"vm-ns","name":"dv1"}`,
-				`k8s:PersistentVolumeClaim.v1:{"namespace":"vm-ns","name":"dv2"}`,
-			},
-		},
-		{
 			rule: "PVCToPV",
 			start: newK8s("PersistentVolumeClaim", "ns", "pvc-1", k8s.Object{
 				"spec": k8s.Object{
@@ -165,16 +141,6 @@ func TestK8sRules(t *testing.T) {
 				},
 			}),
 			want: []string{`k8s:StorageClass.v1.storage.k8s.io:{"name":"sc-1"}`},
-		},
-		{
-			rule:  "VmToVmi",
-			start: newK8s("VirtualMachine.kubevirt.io", "vm-ns", "vm-name", nil),
-			want:  []string{`k8s:VirtualMachineInstance.v1.kubevirt.io:{"namespace":"vm-ns","name":"vm-name"}`},
-		},
-		{
-			rule:  "VmiToPod",
-			start: newK8s("VirtualMachineInstance.kubevirt.io", "vm-ns", "vm-name", nil),
-			want:  []string{`k8s:Pod.v1:{"namespace":"vm-ns","labels":{"kubevirt.io":"virt-launcher","vm.kubevirt.io/name":"vm-name"}}`},
 		},
 		{
 			rule:  "NodeToPod",

--- a/etc/korrel8r/rules/kubevirt.yaml
+++ b/etc/korrel8r/rules/kubevirt.yaml
@@ -1,0 +1,370 @@
+# Correlation rules for KubeVirt / OpenShift Virtualization resources.
+#
+# CRDs covered:
+#   - VirtualMachine (kubevirt.io/v1)
+#   - VirtualMachineInstance (kubevirt.io/v1)
+#   - VirtualMachineInstanceMigration (kubevirt.io/v1)
+#   - DataVolume (cdi.kubevirt.io/v1beta1)
+#   - VirtualMachineSnapshot (snapshot.kubevirt.io/v1beta1)
+#   - VirtualMachineRestore (snapshot.kubevirt.io/v1beta1)
+#   - VirtualMachineExport (export.kubevirt.io/v1beta1)
+#
+# Metric label conventions in KubeVirt:
+#   - kubevirt_vm_* metrics use label "name" for the VM name
+#   - kubevirt_vmi_* metrics use label "name" for the VMI name
+#   - migration metrics use "vmi" for VMI name and "vmim" for migration name
+
+rules:
+  # ─── VM ↔ VMI / Pod / Node / PVC (core navigation) ──────────────────────────
+
+  - name: VmToVmi
+    start:
+      domain: k8s
+      classes: [VirtualMachine.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [VirtualMachineInstance.kubevirt.io]
+    result:
+      query: |-
+        k8s:VirtualMachineInstance.kubevirt.io:{"namespace":"{{.metadata.namespace}}","name":"{{.metadata.name}}"}
+
+  - name: VmiToPod
+    start:
+      domain: k8s
+      classes: [VirtualMachineInstance.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [Pod]
+    result:
+      query: |-
+        k8s:Pod:{"namespace":"{{.metadata.namespace}}","labels":{"vm.kubevirt.io/name":"{{.metadata.name}}","kubevirt.io":"virt-launcher"}}
+
+  - name: VmiToNode
+    start:
+      domain: k8s
+      classes: [VirtualMachineInstance.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [Node]
+    result:
+      query: |-
+        k8s:Node:{"name":"{{.status.nodeName}}"}
+
+  - name: VmToPVC
+    start:
+      domain: k8s
+      classes: [VirtualMachine.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [PersistentVolumeClaim]
+    result:
+      query: |-
+        {{- range .spec.dataVolumeTemplates }}
+        k8s:PersistentVolumeClaim:{"namespace":"{{$.metadata.namespace}}","name":"{{.metadata.name}}"}
+        {{- end }}
+
+  # ─── Alert ↔ VirtualMachine ────────────────────────────────────────────────
+
+  - name: AlertToVM
+    start:
+      domain: alert
+    goal:
+      domain: k8s
+      classes: [VirtualMachine.kubevirt.io]
+    result:
+      query: |-
+        k8s:VirtualMachine.kubevirt.io:{"namespace":"{{.Labels.namespace}}","name":"{{.Labels.name}}"}
+
+  - name: VmToAlert
+    start:
+      domain: k8s
+      classes: [VirtualMachine.kubevirt.io]
+    goal:
+      domain: alert
+    result:
+      query: |-
+        alert:alert:{"namespace":"{{.metadata.namespace}}","name":"{{.metadata.name}}"}
+
+  # ─── Alert ↔ VirtualMachineInstance ────────────────────────────────────────
+
+  - name: AlertToVMI
+    start:
+      domain: alert
+    goal:
+      domain: k8s
+      classes: [VirtualMachineInstance.kubevirt.io]
+    result:
+      query: |-
+        k8s:VirtualMachineInstance.kubevirt.io:{"namespace":"{{.Labels.namespace}}","name":"{{.Labels.name}}"}
+
+  - name: VmiToAlert
+    start:
+      domain: k8s
+      classes: [VirtualMachineInstance.kubevirt.io]
+    goal:
+      domain: alert
+    result:
+      query: |-
+        alert:alert:{"namespace":"{{.metadata.namespace}}","name":"{{.metadata.name}}"}
+
+  # ─── Alert ↔ VirtualMachineInstanceMigration ───────────────────────────────
+
+  - name: AlertToVmim
+    start:
+      domain: alert
+    goal:
+      domain: k8s
+      classes: [VirtualMachineInstanceMigration.kubevirt.io]
+    result:
+      query: |-
+        k8s:VirtualMachineInstanceMigration.kubevirt.io:{"namespace":"{{.Labels.namespace}}","name":"{{.Labels.vmim}}"}
+
+  - name: VmimToAlert
+    start:
+      domain: k8s
+      classes: [VirtualMachineInstanceMigration.kubevirt.io]
+    goal:
+      domain: alert
+    result:
+      query: |-
+        alert:alert:{"namespace":"{{.metadata.namespace}}","vmim":"{{.metadata.name}}"}
+
+  # ─── VM / VMI → Metrics (KubeVirt-specific label format) ──────────────────
+
+  - name: VmToMetric
+    start:
+      domain: k8s
+      classes: [VirtualMachine.kubevirt.io]
+    goal:
+      domain: metric
+    result:
+      query: |-
+        metric:metric:{namespace="{{.metadata.namespace}}",name="{{.metadata.name}}"}
+
+  - name: VmiToMetric
+    start:
+      domain: k8s
+      classes: [VirtualMachineInstance.kubevirt.io]
+    goal:
+      domain: metric
+    result:
+      query: |-
+        metric:metric:{namespace="{{.metadata.namespace}}",name="{{.metadata.name}}"}
+
+  # ─── VMI → Logs (shortcut: finds virt-launcher pod logs for a VMI) ────────
+
+  - name: VmiToLogs
+    start:
+      domain: k8s
+      classes: [VirtualMachineInstance.kubevirt.io]
+    goal:
+      domain: log
+    result:
+      query: |-
+        log:{{logTypeForNamespace .metadata.namespace}}:{"namespace":"{{.metadata.namespace}}","labels":{"kubevirt.io":"virt-launcher","vm.kubevirt.io/name":"{{.metadata.name}}"}}
+
+  # ─── VirtualMachineInstanceMigration ↔ VMI ────────────────────────────────
+
+  - name: VmimToVmi
+    start:
+      domain: k8s
+      classes: [VirtualMachineInstanceMigration.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [VirtualMachineInstance.kubevirt.io]
+    result:
+      query: |-
+        k8s:VirtualMachineInstance.kubevirt.io:{"namespace":"{{.metadata.namespace}}","name":"{{.spec.vmiName}}"}
+
+  - name: VmiToVmim
+    start:
+      domain: k8s
+      classes: [VirtualMachineInstance.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [VirtualMachineInstanceMigration.kubevirt.io]
+    result:
+      query: |-
+        k8s:VirtualMachineInstanceMigration.kubevirt.io:{"namespace":"{{.metadata.namespace}}","labels":{"kubevirt.io/vmi-name":"{{.metadata.name}}"}}
+
+  # ─── DataVolume ↔ PVC ─────────────────────────────────────────────────────
+
+  - name: DataVolumeToPVC
+    start:
+      domain: k8s
+      classes: [DataVolume.cdi.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [PersistentVolumeClaim]
+    result:
+      query: |-
+        k8s:PersistentVolumeClaim:{"namespace":"{{.metadata.namespace}}","name":"{{.metadata.name}}"}
+
+  # ─── VirtualMachine ↔ DataVolume ──────────────────────────────────────────
+
+  - name: VmToDataVolume
+    start:
+      domain: k8s
+      classes: [VirtualMachine.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [DataVolume.cdi.kubevirt.io]
+    result:
+      query: |-
+        {{- range .spec.dataVolumeTemplates }}
+        k8s:DataVolume.cdi.kubevirt.io:{"namespace":"{{$.metadata.namespace}}","name":"{{.metadata.name}}"}
+        {{- end }}
+
+  # ─── VirtualMachineSnapshot ↔ VirtualMachine ─────────────────────────────
+
+  - name: VmSnapshotToVm
+    start:
+      domain: k8s
+      classes: [VirtualMachineSnapshot.snapshot.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [VirtualMachine.kubevirt.io]
+    result:
+      query: |-
+        k8s:VirtualMachine.kubevirt.io:{"namespace":"{{.metadata.namespace}}","name":"{{.spec.source.name}}"}
+
+  - name: VmToVmSnapshot
+    start:
+      domain: k8s
+      classes: [VirtualMachine.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [VirtualMachineSnapshot.snapshot.kubevirt.io]
+    result:
+      query: |-
+        k8s:VirtualMachineSnapshot.snapshot.kubevirt.io:{"namespace":"{{.metadata.namespace}}","labels":{"vm.kubevirt.io/name":"{{.metadata.name}}"}}
+
+  # ─── VirtualMachineRestore ↔ VirtualMachine ──────────────────────────────
+
+  - name: VmRestoreToVm
+    start:
+      domain: k8s
+      classes: [VirtualMachineRestore.snapshot.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [VirtualMachine.kubevirt.io]
+    result:
+      query: |-
+        k8s:VirtualMachine.kubevirt.io:{"namespace":"{{.metadata.namespace}}","name":"{{.spec.target.name}}"}
+
+  - name: VmToVmRestore
+    start:
+      domain: k8s
+      classes: [VirtualMachine.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [VirtualMachineRestore.snapshot.kubevirt.io]
+    result:
+      query: |-
+        k8s:VirtualMachineRestore.snapshot.kubevirt.io:{"namespace":"{{.metadata.namespace}}","labels":{"vm.kubevirt.io/name":"{{.metadata.name}}"}}
+
+  # ─── VirtualMachineRestore → VirtualMachineSnapshot ───────────────────────
+
+  - name: VmRestoreToVmSnapshot
+    start:
+      domain: k8s
+      classes: [VirtualMachineRestore.snapshot.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [VirtualMachineSnapshot.snapshot.kubevirt.io]
+    result:
+      query: |-
+        k8s:VirtualMachineSnapshot.snapshot.kubevirt.io:{"namespace":"{{.metadata.namespace}}","name":"{{.spec.virtualMachineSnapshotName}}"}
+
+  # ─── VirtualMachineExport → source resource ───────────────────────────────
+
+  - name: VmExportToVm
+    start:
+      domain: k8s
+      classes: [VirtualMachineExport.export.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [VirtualMachine.kubevirt.io]
+    result:
+      query: |-
+        {{- if eq .spec.source.kind "VirtualMachine" -}}
+        k8s:VirtualMachine.kubevirt.io:{"namespace":"{{.metadata.namespace}}","name":"{{.spec.source.name}}"}
+        {{- end -}}
+
+  - name: VmExportToVmSnapshot
+    start:
+      domain: k8s
+      classes: [VirtualMachineExport.export.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [VirtualMachineSnapshot.snapshot.kubevirt.io]
+    result:
+      query: |-
+        {{- if eq .spec.source.kind "VirtualMachineSnapshot" -}}
+        k8s:VirtualMachineSnapshot.snapshot.kubevirt.io:{"namespace":"{{.metadata.namespace}}","name":"{{.spec.source.name}}"}
+        {{- end -}}
+
+  - name: VmExportToPVC
+    start:
+      domain: k8s
+      classes: [VirtualMachineExport.export.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [PersistentVolumeClaim]
+    result:
+      query: |-
+        {{- if eq .spec.source.kind "PersistentVolumeClaim" -}}
+        k8s:PersistentVolumeClaim:{"namespace":"{{.metadata.namespace}}","name":"{{.spec.source.name}}"}
+        {{- end -}}
+
+  # ─── Node → VMIs running on it (impact assessment) ────────────────────────
+  # KubeVirt labels VMIs with kubevirt.io/nodeName after scheduling.
+
+  - name: NodeToVmi
+    start:
+      domain: k8s
+      classes: [Node]
+    goal:
+      domain: k8s
+      classes: [VirtualMachineInstance.kubevirt.io]
+    result:
+      query: |-
+        k8s:VirtualMachineInstance.kubevirt.io:{"labels":{"kubevirt.io/nodeName":"{{.metadata.name}}"}}
+
+  # ─── DataVolume → CDI importer Pod (disk provisioning debugging) ───────────
+  # CDI creates importer pods labeled with the PVC name they're populating.
+  # DataVolume and its PVC share the same namespace/name.
+
+  - name: DataVolumeToImporterPod
+    start:
+      domain: k8s
+      classes: [DataVolume.cdi.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [Pod]
+    result:
+      query: |-
+        k8s:Pod:{"namespace":"{{.metadata.namespace}}","labels":{"cdi.kubevirt.io/storage.import.importPvcName":"{{.metadata.name}}"}}
+
+  # ─── VMI → NetworkAttachmentDefinition (Multus network debugging) ──────────
+  # VMIs reference NADs in spec.networks[].multus.networkName.
+  # Note: only handles same-namespace NADs (format "name").
+  # Cross-namespace format ("namespace/name") requires splitting which
+  # Go templates cannot do without a custom function.
+
+  - name: VmiToNetAttachDef
+    start:
+      domain: k8s
+      classes: [VirtualMachineInstance.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [NetworkAttachmentDefinition.k8s.cni.cncf.io]
+    result:
+      query: |-
+        {{- range .spec.networks }}
+        {{- with index . "multus" }}
+        {{- if not (contains "/" .networkName) }}
+        k8s:NetworkAttachmentDefinition.k8s.cni.cncf.io:{"namespace":"{{$.metadata.namespace}}","name":"{{.networkName}}"}
+        {{- end }}
+        {{- end }}
+        {{- end }}

--- a/etc/korrel8r/rules/kubevirt_test.go
+++ b/etc/korrel8r/rules/kubevirt_test.go
@@ -1,0 +1,212 @@
+// Copyright: This file is part of korrel8r, released under https://github.com/korrel8r/korrel8r/blob/main/LICENSE
+
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/korrel8r/korrel8r/pkg/domains/alert"
+	"github.com/korrel8r/korrel8r/pkg/domains/k8s"
+)
+
+func TestKubevirtRules(t *testing.T) {
+	for _, x := range []ruleTest{
+		{
+			rule:  "VmToVmi",
+			start: newK8s("VirtualMachine.kubevirt.io", "vm-ns", "vm-name", nil),
+			want:  []string{`k8s:VirtualMachineInstance.v1.kubevirt.io:{"namespace":"vm-ns","name":"vm-name"}`},
+		},
+		{
+			rule:  "VmiToPod",
+			start: newK8s("VirtualMachineInstance.kubevirt.io", "vm-ns", "vm-name", nil),
+			want:  []string{`k8s:Pod.v1:{"namespace":"vm-ns","labels":{"kubevirt.io":"virt-launcher","vm.kubevirt.io/name":"vm-name"}}`},
+		},
+		{
+			rule: "VmiToNode",
+			start: newK8s("VirtualMachineInstance.kubevirt.io", "vm-ns", "vm-name", k8s.Object{
+				"status": k8s.Object{
+					"nodeName": "worker-1",
+				},
+			}),
+			want: []string{`k8s:Node.v1:{"name":"worker-1"}`},
+		},
+		{
+			rule: "VmToPVC",
+			start: newK8s("VirtualMachine.kubevirt.io", "vm-ns", "vm-name", k8s.Object{
+				"spec": k8s.Object{
+					"dataVolumeTemplates": []k8s.Object{
+						{"metadata": k8s.Object{"name": "dv1"}},
+						{"metadata": k8s.Object{"name": "dv2"}},
+					},
+				},
+			}),
+			want: []string{
+				`k8s:PersistentVolumeClaim.v1:{"namespace":"vm-ns","name":"dv1"}`,
+				`k8s:PersistentVolumeClaim.v1:{"namespace":"vm-ns","name":"dv2"}`,
+			},
+		},
+		{
+			rule:  "AlertToVM",
+			start: &alert.Object{Labels: map[string]string{"namespace": "vm-ns", "name": "my-vm"}},
+			want:  []string{`k8s:VirtualMachine.v1.kubevirt.io:{"namespace":"vm-ns","name":"my-vm"}`},
+		},
+		{
+			rule:  "VmToAlert",
+			start: newK8s("VirtualMachine.kubevirt.io", "vm-ns", "my-vm", nil),
+			want:  []string{`alert:alert:{"namespace":"vm-ns","name":"my-vm"}`},
+		},
+		{
+			rule:  "AlertToVMI",
+			start: &alert.Object{Labels: map[string]string{"namespace": "vm-ns", "name": "my-vmi"}},
+			want:  []string{`k8s:VirtualMachineInstance.v1.kubevirt.io:{"namespace":"vm-ns","name":"my-vmi"}`},
+		},
+		{
+			rule:  "VmiToAlert",
+			start: newK8s("VirtualMachineInstance.kubevirt.io", "vm-ns", "my-vmi", nil),
+			want:  []string{`alert:alert:{"namespace":"vm-ns","name":"my-vmi"}`},
+		},
+		{
+			rule:  "AlertToVmim",
+			start: &alert.Object{Labels: map[string]string{"namespace": "vm-ns", "vmim": "my-migration"}},
+			want:  []string{`k8s:VirtualMachineInstanceMigration.v1.kubevirt.io:{"namespace":"vm-ns","name":"my-migration"}`},
+		},
+		{
+			rule:  "VmimToAlert",
+			start: newK8s("VirtualMachineInstanceMigration.kubevirt.io", "vm-ns", "my-migration", nil),
+			want:  []string{`alert:alert:{"namespace":"vm-ns","vmim":"my-migration"}`},
+		},
+		{
+			rule:  "VmToMetric",
+			start: newK8s("VirtualMachine.kubevirt.io", "vm-ns", "my-vm", nil),
+			want:  []string{`metric:metric:{namespace="vm-ns",name="my-vm"}`},
+		},
+		{
+			rule:  "VmiToMetric",
+			start: newK8s("VirtualMachineInstance.kubevirt.io", "vm-ns", "my-vmi", nil),
+			want:  []string{`metric:metric:{namespace="vm-ns",name="my-vmi"}`},
+		},
+		{
+			rule:  "VmiToLogs",
+			start: newK8s("VirtualMachineInstance.kubevirt.io", "vm-ns", "my-vmi", nil),
+			want:  []string{`log:application:{"namespace":"vm-ns","labels":{"kubevirt.io":"virt-launcher","vm.kubevirt.io/name":"my-vmi"}}`},
+		},
+		{
+			rule: "VmimToVmi",
+			start: newK8s("VirtualMachineInstanceMigration.kubevirt.io", "vm-ns", "mig-1", k8s.Object{
+				"spec": k8s.Object{
+					"vmiName": "my-vmi",
+				},
+			}),
+			want: []string{`k8s:VirtualMachineInstance.v1.kubevirt.io:{"namespace":"vm-ns","name":"my-vmi"}`},
+		},
+		{
+			rule:  "VmiToVmim",
+			start: newK8s("VirtualMachineInstance.kubevirt.io", "vm-ns", "my-vmi", nil),
+			want:  []string{`k8s:VirtualMachineInstanceMigration.v1.kubevirt.io:{"namespace":"vm-ns","labels":{"kubevirt.io/vmi-name":"my-vmi"}}`},
+		},
+		{
+			rule:  "DataVolumeToPVC",
+			start: newK8s("DataVolume.cdi.kubevirt.io", "vm-ns", "my-dv", nil),
+			want:  []string{`k8s:PersistentVolumeClaim.v1:{"namespace":"vm-ns","name":"my-dv"}`},
+		},
+		{
+			rule: "VmToDataVolume",
+			start: newK8s("VirtualMachine.kubevirt.io", "vm-ns", "my-vm", k8s.Object{
+				"spec": k8s.Object{
+					"dataVolumeTemplates": []k8s.Object{
+						{"metadata": k8s.Object{"name": "dv1"}},
+					},
+				},
+			}),
+			want: []string{`k8s:DataVolume.v1beta1.cdi.kubevirt.io:{"namespace":"vm-ns","name":"dv1"}`},
+		},
+		{
+			rule: "VmSnapshotToVm",
+			start: newK8s("VirtualMachineSnapshot.snapshot.kubevirt.io", "vm-ns", "snap-1", k8s.Object{
+				"spec": k8s.Object{
+					"source": k8s.Object{"name": "my-vm"},
+				},
+			}),
+			want: []string{`k8s:VirtualMachine.v1.kubevirt.io:{"namespace":"vm-ns","name":"my-vm"}`},
+		},
+		{
+			rule:  "VmToVmSnapshot",
+			start: newK8s("VirtualMachine.kubevirt.io", "vm-ns", "my-vm", nil),
+			want:  []string{`k8s:VirtualMachineSnapshot.v1beta1.snapshot.kubevirt.io:{"namespace":"vm-ns","labels":{"vm.kubevirt.io/name":"my-vm"}}`},
+		},
+		{
+			rule: "VmRestoreToVm",
+			start: newK8s("VirtualMachineRestore.snapshot.kubevirt.io", "vm-ns", "restore-1", k8s.Object{
+				"spec": k8s.Object{
+					"target": k8s.Object{"name": "my-vm"},
+				},
+			}),
+			want: []string{`k8s:VirtualMachine.v1.kubevirt.io:{"namespace":"vm-ns","name":"my-vm"}`},
+		},
+		{
+			rule:  "VmToVmRestore",
+			start: newK8s("VirtualMachine.kubevirt.io", "vm-ns", "my-vm", nil),
+			want:  []string{`k8s:VirtualMachineRestore.v1beta1.snapshot.kubevirt.io:{"namespace":"vm-ns","labels":{"vm.kubevirt.io/name":"my-vm"}}`},
+		},
+		{
+			rule: "VmRestoreToVmSnapshot",
+			start: newK8s("VirtualMachineRestore.snapshot.kubevirt.io", "vm-ns", "restore-1", k8s.Object{
+				"spec": k8s.Object{
+					"virtualMachineSnapshotName": "snap-1",
+				},
+			}),
+			want: []string{`k8s:VirtualMachineSnapshot.v1beta1.snapshot.kubevirt.io:{"namespace":"vm-ns","name":"snap-1"}`},
+		},
+		{
+			rule: "VmExportToVm",
+			start: newK8s("VirtualMachineExport.export.kubevirt.io", "vm-ns", "export-1", k8s.Object{
+				"spec": k8s.Object{
+					"source": k8s.Object{"kind": "VirtualMachine", "name": "my-vm"},
+				},
+			}),
+			want: []string{`k8s:VirtualMachine.v1.kubevirt.io:{"namespace":"vm-ns","name":"my-vm"}`},
+		},
+		{
+			rule: "VmExportToVmSnapshot",
+			start: newK8s("VirtualMachineExport.export.kubevirt.io", "vm-ns", "export-1", k8s.Object{
+				"spec": k8s.Object{
+					"source": k8s.Object{"kind": "VirtualMachineSnapshot", "name": "snap-1"},
+				},
+			}),
+			want: []string{`k8s:VirtualMachineSnapshot.v1beta1.snapshot.kubevirt.io:{"namespace":"vm-ns","name":"snap-1"}`},
+		},
+		{
+			rule: "VmExportToPVC",
+			start: newK8s("VirtualMachineExport.export.kubevirt.io", "vm-ns", "export-1", k8s.Object{
+				"spec": k8s.Object{
+					"source": k8s.Object{"kind": "PersistentVolumeClaim", "name": "my-pvc"},
+				},
+			}),
+			want: []string{`k8s:PersistentVolumeClaim.v1:{"namespace":"vm-ns","name":"my-pvc"}`},
+		},
+		{
+			rule:  "NodeToVmi",
+			start: newK8s("Node", "", "worker-1", nil),
+			want:  []string{`k8s:VirtualMachineInstance.v1.kubevirt.io:{"labels":{"kubevirt.io/nodeName":"worker-1"}}`},
+		},
+		{
+			rule:  "DataVolumeToImporterPod",
+			start: newK8s("DataVolume.cdi.kubevirt.io", "vm-ns", "my-dv", nil),
+			want:  []string{`k8s:Pod.v1:{"namespace":"vm-ns","labels":{"cdi.kubevirt.io/storage.import.importPvcName":"my-dv"}}`},
+		},
+		{
+			rule: "VmiToNetAttachDef",
+			start: newK8s("VirtualMachineInstance.kubevirt.io", "vm-ns", "my-vmi", k8s.Object{
+				"spec": k8s.Object{
+					"networks": []k8s.Object{
+						{"name": "default", "pod": k8s.Object{}},
+						{"name": "net1", "multus": k8s.Object{"networkName": "my-nad"}},
+					},
+				},
+			}),
+			want: []string{`k8s:NetworkAttachmentDefinition.v1.k8s.cni.cncf.io:{"namespace":"vm-ns","name":"my-nad"}`},
+		},
+	} {
+		x.Run(t)
+	}
+}

--- a/etc/korrel8r/rules/rules_test.go
+++ b/etc/korrel8r/rules/rules_test.go
@@ -53,6 +53,32 @@ var customResourcesForTests = []*metav1.APIResourceList{
 		APIResources: []metav1.APIResource{
 			{Kind: "VirtualMachineInstance", Namespaced: true},
 			{Kind: "VirtualMachine", Namespaced: true},
+			{Kind: "VirtualMachineInstanceMigration", Namespaced: true},
+		},
+	},
+	{
+		GroupVersion: "cdi.kubevirt.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{Kind: "DataVolume", Namespaced: true},
+		},
+	},
+	{
+		GroupVersion: "snapshot.kubevirt.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{Kind: "VirtualMachineSnapshot", Namespaced: true},
+			{Kind: "VirtualMachineRestore", Namespaced: true},
+		},
+	},
+	{
+		GroupVersion: "export.kubevirt.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{Kind: "VirtualMachineExport", Namespaced: true},
+		},
+	},
+	{
+		GroupVersion: "k8s.cni.cncf.io/v1",
+		APIResources: []metav1.APIResource{
+			{Kind: "NetworkAttachmentDefinition", Namespaced: true},
 		},
 	},
 	{


### PR DESCRIPTION
Consolidate all KubeVirt rules into a dedicated kubevirt.yaml file:
- Move existing VmToVmi, VmiToPod, VmiToNode, VmToPVC from k8s.yaml
- Add 24 new correlation rules covering KubeVirt CRDs

New rules added:
- Alert ↔ VM/VMI/VMIM (bidirectional)
- VM/VMI → Metrics (KubeVirt-specific "name" label format)
- VMI → Logs (via virt-launcher pod labels)
- VMIM ↔ VMI (bidirectional, uses spec.vmiName / label selector)
- DataVolume → PVC and CDI importer Pod
- VM ↔ Snapshots and Restores (bidirectional via labels)
- VirtualMachineExport → source resources (VM/Snapshot/PVC)
- Node → VMIs running on it (impact assessment)
- VMI → NetworkAttachmentDefinition (Multus network debugging)

Registers new CRD types (cdi.kubevirt.io, snapshot.kubevirt.io,
export.kubevirt.io, k8s.cni.cncf.io) in the test framework and adds
unit tests for every rule.

* Jira-url: https://redhat.atlassian.net/browse/CNV-92145

Signed-off-by: Shirly Radco <sradco@redhat.com>
Co-authored-by: Cursor <cursoragent@cursor.com>

Made with [Cursor](https://cursor.com)