### PR TITLE
refactor: simplify console connection logic

### DIFF
--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -105,12 +105,6 @@ func NewServer(sessions session.Manager) *Server {
 			&mcp.Implementation{Name: "korrel8r", Title: "Korrel8r MCP Server", Version: build.Version},
 			&mcp.ServerOptions{
 				Instructions: instructions,
-				InitializedHandler: func(ctx context.Context, _ *mcp.InitializedRequest) {
-					if ss, err := sessions.Get(ctx); err == nil {
-						// Send an empty event to announce we are connected.
-						ss.Send(&api.Console{})
-					}
-				},
 			}),
 		sessions: sessions,
 	}

--- a/pkg/mcp/mcp_test.go
+++ b/pkg/mcp/mcp_test.go
@@ -477,7 +477,7 @@ func TestInterop_ShowInConsoleToSSE(t *testing.T) {
 		_ = s.Err()
 	}()
 
-	// Send console update via MCP show_in_console.
+	time.Sleep(100 * time.Millisecond) // Let ConsoleEvents enter its select loop.
 	want := api.Console{View: "mock:a:x"}
 	r, err := f.mcp.CallTool(context.Background(), &mcp.CallToolParams{
 		Name:      ShowInConsole,
@@ -486,17 +486,6 @@ func TestInterop_ShowInConsoleToSSE(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, r.IsError, "show_in_console should succeed")
 
-	// First event is the empty MCP-connected signal.
-	select {
-	case data := <-events:
-		var got api.Console
-		require.NoError(t, json.Unmarshal([]byte(data), &got))
-		assert.Equal(t, api.Console{}, got)
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for MCP connection event")
-	}
-
-	// Second event is the actual update.
 	select {
 	case data := <-events:
 		var got api.Console
@@ -649,12 +638,13 @@ func TestMultiSession_SSEIsolation(t *testing.T) {
 		return events
 	}
 
+	csA := f.mcpClient(t, "token-A")
+	_ = f.mcpClient(t, "token-B")
+
 	eventsA := connectSSE("token-A")
 	eventsB := connectSSE("token-B")
-	time.Sleep(100 * time.Millisecond) // let SSE handlers start
+	time.Sleep(100 * time.Millisecond) // Let both ConsoleEvents loops start.
 
-	// MCP client for token-A sends a console update.
-	csA := f.mcpClient(t, "token-A")
 	r, err := csA.CallTool(context.Background(), &mcp.CallToolParams{
 		Name:      ShowInConsole,
 		Arguments: ShowInConsoleParams{View: "mock:a:x"},
@@ -662,18 +652,17 @@ func TestMultiSession_SSEIsolation(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, r.IsError)
 
-	receive := func(events <-chan string) api.Console {
-		data := <-events
+	// Session A receives the update.
+	select {
+	case data := <-eventsA:
 		var got api.Console
 		require.NoError(t, json.Unmarshal([]byte(data), &got))
-		return got
+		assert.Equal(t, api.Console{View: "mock:a:x"}, got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for SSE event on session-A")
 	}
-	// MCP Connection event
-	assert.Equal(t, api.Console{}, receive(eventsA))
-	// Expected update.
-	assert.Equal(t, api.Console{View: "mock:a:x"}, receive(eventsA))
 
-	// Session B's SSE client should NOT receive anything.
+	// Session B should NOT receive anything.
 	select {
 	case data := <-eventsB:
 		t.Fatalf("session B should not receive session A's update, got: %s", data)

--- a/pkg/rest/operations.go
+++ b/pkg/rest/operations.go
@@ -245,18 +245,7 @@ func (a *API) ConsoleEvents(c *gin.Context) {
 		return
 	}
 
-	if !check(c, http.StatusConflict, s.Listen()) {
-		return
-	}
-	defer s.Close()
-
 	w := c.Writer
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Headers", "Cache-Control")
-	w.Flush()
 
 	// Strip the middleware's request timeout — SSE is long-lived.
 	// context.WithoutCancel preserves values but detaches from the deadline,
@@ -268,9 +257,22 @@ func (a *API) ConsoleEvents(c *gin.Context) {
 
 	err = s.ConsoleEvents(
 		ctx,
+		func() error {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("Connection", "keep-alive")
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Headers", "Cache-Control")
+			w.Flush()
+			return nil
+		},
 		func(c *api.Console) error { return a.sendEvent(w, c) },
 		func() error { _, err := fmt.Fprint(w, ":keepalive\n\n"); w.Flush(); return err },
 		3*time.Second)
+	if errors.Is(err, session.ErrConsoleBusy) {
+		check(c, http.StatusConflict, err)
+		return
+	}
 	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 		log.V(3).Error(err, "Console SSE error", "session", s)
 	}

--- a/pkg/session/console.go
+++ b/pkg/session/console.go
@@ -19,84 +19,56 @@ var (
 // consoleEvents implements the MCP-to-REST and REST-to-MCP pathways through a session.
 // Only one console SSE listener can be active per session.
 type consoleEvents struct {
-	session      string
-	fromConsole  atomic.Pointer[api.Console] // Latest state from console (REST→MCP).
-	toConsole    chan *api.Console           // Latest-value channel for console updates (MCP→REST).
-	connected    atomic.Bool                 // True while an SSE listener is connected.
-	mcpConnected atomic.Bool                 // True once ShowInConsole has been called; survives listener reconnects.
+	fromConsole atomic.Pointer[api.Console] // Latest state from console (REST→MCP).
+	toConsole   chan *api.Console           // Latest-value channel for console updates (MCP→REST).
+	connected   atomic.Bool                 // True while an SSE listener is connected.
 }
 
-func newConsoleEvents(session string) *consoleEvents {
+func newConsoleEvents() *consoleEvents {
 	return &consoleEvents{
-		session:   session,
-		toConsole: make(chan *api.Console, 1),
+		toConsole: make(chan *api.Console),
 	}
 }
 
-// Listen registers the SSE listener for this session.
-// Returns ErrConsoleBusy if a listener is already connected.
-// The caller must call Close when done.
-func (c *consoleEvents) Listen() error {
-	if !c.connected.CompareAndSwap(false, true) {
-		return ErrConsoleBusy
-	}
-	return nil
-}
-
-// Close removes the active SSE listener and drains pending updates.
-func (c *consoleEvents) Close() {
-	c.connected.Store(false)
-	c.fromConsole.Store(nil)
-	select {
-	case <-c.toConsole:
-	default:
-	}
-}
-
-// ShowInConsole enqueues an update for the console SSE listener.
+// ShowInConsole sends an update to the console SSE listener.
 // Returns ErrNoConsole if no listener is connected.
-// The latest value wins: any stale pending update is replaced.
+// Drops the update if the listener is not ready to receive.
 func (c *consoleEvents) ShowInConsole(update *api.Console) error {
-	if !c.connected.Load() {
-		return ErrNoConsole
-	}
-	c.mcpConnected.Store(true)
-	c.Send(update)
-	return nil
-}
-
-// Send enqueues an update without requiring a connected listener.
-// Use this for signals (like MCP connection) that may arrive before the SSE listener starts.
-func (c *consoleEvents) Send(update *api.Console) {
-	// Drain old value
-	select {
-	case <-c.toConsole:
-	default:
-	}
-	// Post new value
 	select {
 	case c.toConsole <- update:
+		return nil
 	default:
+		return ErrNoConsole
 	}
 }
 
 // ConsoleEvents loops sending updates and keepalives until ctx is canceled or a send fails.
+// Returns ErrConsoleBusy if another listener is already connected.
+// ready (if non-nil) is called after acquiring the connection slot but before entering the loop.
 // ctx should be the HTTP request context, which cancels on client disconnect.
 // Avoid passing a context with a short timeout — this is a long-lived SSE subscription.
-//
-// The caller must call SetListener before this and ClearListener after.
 func (c *consoleEvents) ConsoleEvents(
 	ctx context.Context,
+	ready func() error,
 	send func(*api.Console) error,
 	tick func() error,
 	tickInterval time.Duration) error {
 
-	// Send empty "connected" notification directly (not via channel, to preserve pending updates).
-	if c.mcpConnected.Load() {
-		if err := send(&api.Console{}); err != nil {
+	// Only allow one connection at a time.
+	if !c.connected.CompareAndSwap(false, true) {
+		return ErrConsoleBusy
+	}
+	defer func() {
+		c.connected.Store(false)
+		c.fromConsole.Store(nil)
+	}()
+
+	if ready != nil {
+		if err := ready(); err != nil {
 			return err
 		}
 	}
+
 	ticker := time.NewTicker(tickInterval)
 	defer ticker.Stop()
 	for {

--- a/pkg/session/console_test.go
+++ b/pkg/session/console_test.go
@@ -14,168 +14,65 @@ import (
 
 func console(view string) *api.Console { return &api.Console{View: api.Query(view)} }
 
-func TestSetListener_Busy(t *testing.T) {
-	c := newConsoleEvents("test")
-	require.NoError(t, c.Listen())
-	defer c.Close()
-	assert.ErrorIs(t, c.Listen(), ErrConsoleBusy)
-}
+func noop(*api.Console) error { return nil }
 
-func TestSetListener_Reuse(t *testing.T) {
-	c := newConsoleEvents("test")
-	require.NoError(t, c.Listen())
-	c.Close()
-	require.NoError(t, c.Listen())
-	c.Close()
-}
-
-func TestShowInConsole_NoListener(t *testing.T) {
-	c := newConsoleEvents("test")
+func TestShowInConsole_ErrNoConsole(t *testing.T) {
+	c := newConsoleEvents()
 	assert.ErrorIs(t, c.ShowInConsole(console("v1")), ErrNoConsole)
 }
 
-func TestShowInConsole_Send(t *testing.T) {
-	c := newConsoleEvents("test")
-	require.NoError(t, c.Listen())
-	defer c.Close()
-	require.NoError(t, c.ShowInConsole(console("v1")))
-	select {
-	case got := <-c.toConsole:
-		assert.Equal(t, console("v1"), got)
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for update")
-	}
-}
+func TestConsoleEvents_ErrConsoleBusy(t *testing.T) {
+	c := newConsoleEvents()
 
-func TestShowInConsole_LatestValueWins(t *testing.T) {
-	c := newConsoleEvents("test")
-	require.NoError(t, c.Listen())
-	defer c.Close()
-	require.NoError(t, c.ShowInConsole(console("v1")))
-	require.NoError(t, c.ShowInConsole(console("v2")))
-	select {
-	case got := <-c.toConsole:
-		assert.Equal(t, console("v2"), got)
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for update")
-	}
-}
+	// Two competing calls, one will return ErrConsoleBusy
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 2)
+	go func() { errCh <- c.ConsoleEvents(ctx, nil, noop, func() error { return nil }, time.Hour) }()
+	go func() { errCh <- c.ConsoleEvents(ctx, nil, noop, func() error { return nil }, time.Hour) }()
+	assert.ErrorIs(t, <-errCh, ErrConsoleBusy)
+	cancel()
+	assert.ErrorIs(t, <-errCh, context.Canceled)
 
-func TestClearListener_DrainsPending(t *testing.T) {
-	c := newConsoleEvents("test")
-	require.NoError(t, c.Listen())
-	require.NoError(t, c.ShowInConsole(console("v1")))
-	c.Close()
+	// Next call should be OK, previous calls are over.
+	ctx, cancel = context.WithCancel(context.Background())
+	go func() { errCh <- c.ConsoleEvents(ctx, nil, noop, func() error { return nil }, time.Hour) }()
 	select {
-	case <-c.toConsole:
-		t.Fatal("expected channel to be drained")
+	case err := <-errCh:
+		t.Fatalf("unexpected error: %v", err)
 	default:
 	}
-}
-
-func TestConsoleState(t *testing.T) {
-	c := newConsoleEvents("test")
-	assert.Nil(t, c.ConsoleState())
-	c.SetConsoleState(console("state1"))
-	assert.Equal(t, console("state1"), c.ConsoleState())
-}
-
-func TestClearListener_ResetsConsoleState(t *testing.T) {
-	c := newConsoleEvents("test")
-	require.NoError(t, c.Listen())
-	c.SetConsoleState(console("state1"))
-	c.Close()
-	assert.Nil(t, c.ConsoleState())
+	cancel()
+	assert.ErrorIs(t, <-errCh, context.Canceled)
 }
 
 func TestConsoleEvents_SendsUpdates(t *testing.T) {
-	c := newConsoleEvents("test")
-	require.NoError(t, c.Listen())
-	defer c.Close()
-
+	c := newConsoleEvents()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	var received []*api.Console
 	send := func(u *api.Console) error {
 		received = append(received, u)
-		if len(received) == 3 {
+		if len(received) == 2 {
 			cancel()
 		}
 		return nil
 	}
 
-	// ShowInConsole sets mcpConnected, so ConsoleEvents sends an initial empty event.
+	errCh := make(chan error)
+	go func() { errCh <- c.ConsoleEvents(ctx, nil, send, func() error { return nil }, time.Hour) }()
+	time.Sleep(10 * time.Millisecond)
+
 	require.NoError(t, c.ShowInConsole(console("v1")))
+	time.Sleep(10 * time.Millisecond)
+	require.NoError(t, c.ShowInConsole(console("v2")))
 
-	go func() {
-		time.Sleep(10 * time.Millisecond)
-		require.NoError(t, c.ShowInConsole(console("v2")))
-	}()
-
-	err := c.ConsoleEvents(ctx, send, func() error { return nil }, time.Hour)
-	assert.ErrorIs(t, err, context.Canceled)
-	assert.Equal(t, []*api.Console{{}, console("v1"), console("v2")}, received)
-}
-
-func TestConsoleEvents_SendBeforeListen(t *testing.T) {
-	c := newConsoleEvents("test")
-	c.Send(&api.Console{})
-
-	require.NoError(t, c.Listen())
-	defer c.Close()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	var received []*api.Console
-	send := func(u *api.Console) error {
-		received = append(received, u)
-		cancel()
-		return nil
-	}
-
-	err := c.ConsoleEvents(ctx, send, func() error { return nil }, time.Hour)
-	assert.ErrorIs(t, err, context.Canceled)
-	assert.Equal(t, []*api.Console{{}}, received)
-}
-
-func TestConsoleEvents_ReconnectSendsEmpty(t *testing.T) {
-	c := newConsoleEvents("test")
-	require.NoError(t, c.Listen())
-
-	// MCP connects via ShowInConsole, consumed by the first loop.
-	require.NoError(t, c.ShowInConsole(console("v1")))
-	ctx1, cancel1 := context.WithCancel(context.Background())
-	go func() {
-		time.Sleep(10 * time.Millisecond)
-		cancel1()
-	}()
-	_ = c.ConsoleEvents(ctx1, func(*api.Console) error { return nil }, func() error { return nil }, time.Hour)
-	c.Close()
-
-	// New listener reconnects — gets initial empty because mcpConnected persists.
-	require.NoError(t, c.Listen())
-	defer c.Close()
-
-	ctx2, cancel2 := context.WithCancel(context.Background())
-	defer cancel2()
-
-	var received []*api.Console
-	err := c.ConsoleEvents(ctx2, func(u *api.Console) error {
-		received = append(received, u)
-		cancel2()
-		return nil
-	}, func() error { return nil }, time.Hour)
-	assert.ErrorIs(t, err, context.Canceled)
-	assert.Equal(t, []*api.Console{{}}, received)
+	assert.ErrorIs(t, <-errCh, context.Canceled)
+	assert.Equal(t, []*api.Console{console("v1"), console("v2")}, received)
 }
 
 func TestConsoleEvents_Tick(t *testing.T) {
-	c := newConsoleEvents("test")
-	require.NoError(t, c.Listen())
-	defer c.Close()
-
+	c := newConsoleEvents()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -188,7 +85,27 @@ func TestConsoleEvents_Tick(t *testing.T) {
 		return nil
 	}
 
-	err := c.ConsoleEvents(ctx, func(*api.Console) error { return nil }, tick, 10*time.Millisecond)
+	err := c.ConsoleEvents(ctx, nil, noop, tick, 10*time.Millisecond)
 	assert.ErrorIs(t, err, context.Canceled)
 	assert.GreaterOrEqual(t, tickCount, 2)
+}
+
+func TestConsoleState(t *testing.T) {
+	c := newConsoleEvents()
+	assert.Nil(t, c.ConsoleState())
+	c.SetConsoleState(console("state1"))
+	assert.Equal(t, console("state1"), c.ConsoleState())
+}
+
+func TestConsoleEvents_ResetsConsoleState(t *testing.T) {
+	c := newConsoleEvents()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		c.SetConsoleState(console("state1"))
+		cancel()
+	}()
+
+	_ = c.ConsoleEvents(ctx, nil, noop, func() error { return nil }, time.Hour)
+	assert.Nil(t, c.ConsoleState())
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -66,7 +66,7 @@ func newSession(e *engine.Engine, id string) *Session {
 	return &Session{
 		ID:            id,
 		Engine:        e,
-		consoleEvents: newConsoleEvents(id),
+		consoleEvents: newConsoleEvents(),
 	}
 }
 


### PR DESCRIPTION
- synchronous console event handoff, passed immediately or  dropped.
- don't track or notify MCP connection state, not worth it.