### PR TITLE
feat(rules): add comprehensive VM resource correlation rules

### DIFF
--- a/etc/korrel8r/rules/kubevirt.yaml
+++ b/etc/korrel8r/rules/kubevirt.yaml
@@ -4,6 +4,10 @@
 #   - VirtualMachine (kubevirt.io/v1)
 #   - VirtualMachineInstance (kubevirt.io/v1)
 #   - VirtualMachineInstanceMigration (kubevirt.io/v1)
+#   - VirtualMachineInstancetype (instancetype.kubevirt.io/v1beta1)
+#   - VirtualMachineClusterInstancetype (instancetype.kubevirt.io/v1beta1)
+#   - VirtualMachinePreference (instancetype.kubevirt.io/v1beta1)
+#   - VirtualMachineClusterPreference (instancetype.kubevirt.io/v1beta1)
 #   - DataVolume (cdi.kubevirt.io/v1beta1)
 #   - VirtualMachineSnapshot (snapshot.kubevirt.io/v1beta1)
 #   - VirtualMachineRestore (snapshot.kubevirt.io/v1beta1)
@@ -59,8 +63,22 @@ rules:
       classes: [PersistentVolumeClaim]
     result:
       query: |-
-        {{- range .spec.dataVolumeTemplates }}
+        {{- range index .spec "dataVolumeTemplates" }}
         k8s:PersistentVolumeClaim:{"namespace":"{{$.metadata.namespace}}","name":"{{.metadata.name}}"}
+        {{- end }}
+        {{- range .spec.template.spec.volumes }}
+        {{- with index . "persistentVolumeClaim" }}
+        k8s:PersistentVolumeClaim:{"namespace":"{{$.metadata.namespace}}","name":"{{.claimName}}"}
+        {{- end }}
+        {{- with index . "dataVolume" }}
+        k8s:PersistentVolumeClaim:{"namespace":"{{$.metadata.namespace}}","name":"{{.name}}"}
+        {{- end }}
+        {{- with index . "ephemeral" }}
+        k8s:PersistentVolumeClaim:{"namespace":"{{$.metadata.namespace}}","name":"{{.persistentVolumeClaim.claimName}}"}
+        {{- end }}
+        {{- with index . "memoryDump" }}
+        k8s:PersistentVolumeClaim:{"namespace":"{{$.metadata.namespace}}","name":"{{.claimName}}"}
+        {{- end }}
         {{- end }}
 
   # ─── Alert ↔ VirtualMachine ────────────────────────────────────────────────
@@ -211,8 +229,56 @@ rules:
       classes: [DataVolume.cdi.kubevirt.io]
     result:
       query: |-
-        {{- range .spec.dataVolumeTemplates }}
+        {{- range index .spec "dataVolumeTemplates" }}
         k8s:DataVolume.cdi.kubevirt.io:{"namespace":"{{$.metadata.namespace}}","name":"{{.metadata.name}}"}
+        {{- end }}
+        {{- range .spec.template.spec.volumes }}
+        {{- with index . "dataVolume" }}
+        k8s:DataVolume.cdi.kubevirt.io:{"namespace":"{{$.metadata.namespace}}","name":"{{.name}}"}
+        {{- end }}
+        {{- end }}
+
+  # ─── VMI → PVC / DataVolume (running instance storage correlation) ───────
+  # VMI spec.volumes[] is copied from the VM template at launch.
+  # These rules enable storage event correlation from a running VMI.
+
+  - name: VmiToPVC
+    start:
+      domain: k8s
+      classes: [VirtualMachineInstance.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [PersistentVolumeClaim]
+    result:
+      query: |-
+        {{- range .spec.volumes }}
+        {{- with index . "persistentVolumeClaim" }}
+        k8s:PersistentVolumeClaim:{"namespace":"{{$.metadata.namespace}}","name":"{{.claimName}}"}
+        {{- end }}
+        {{- with index . "dataVolume" }}
+        k8s:PersistentVolumeClaim:{"namespace":"{{$.metadata.namespace}}","name":"{{.name}}"}
+        {{- end }}
+        {{- with index . "ephemeral" }}
+        k8s:PersistentVolumeClaim:{"namespace":"{{$.metadata.namespace}}","name":"{{.persistentVolumeClaim.claimName}}"}
+        {{- end }}
+        {{- with index . "memoryDump" }}
+        k8s:PersistentVolumeClaim:{"namespace":"{{$.metadata.namespace}}","name":"{{.claimName}}"}
+        {{- end }}
+        {{- end }}
+
+  - name: VmiToDataVolume
+    start:
+      domain: k8s
+      classes: [VirtualMachineInstance.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [DataVolume.cdi.kubevirt.io]
+    result:
+      query: |-
+        {{- range .spec.volumes }}
+        {{- with index . "dataVolume" }}
+        k8s:DataVolume.cdi.kubevirt.io:{"namespace":"{{$.metadata.namespace}}","name":"{{.name}}"}
+        {{- end }}
         {{- end }}
 
   # ─── VirtualMachineSnapshot ↔ VirtualMachine ─────────────────────────────
@@ -346,11 +412,29 @@ rules:
       query: |-
         k8s:Pod:{"namespace":"{{.metadata.namespace}}","labels":{"cdi.kubevirt.io/storage.import.importPvcName":"{{.metadata.name}}"}}
 
-  # ─── VMI → NetworkAttachmentDefinition (Multus network debugging) ──────────
+  # ─── VM / VMI → NetworkAttachmentDefinition (Multus network debugging) ───
+  # VMs reference NADs in spec.template.spec.networks[].multus.networkName.
   # VMIs reference NADs in spec.networks[].multus.networkName.
   # Note: only handles same-namespace NADs (format "name").
   # Cross-namespace format ("namespace/name") requires splitting which
   # Go templates cannot do without a custom function.
+
+  - name: VmToNetAttachDef
+    start:
+      domain: k8s
+      classes: [VirtualMachine.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [NetworkAttachmentDefinition.k8s.cni.cncf.io]
+    result:
+      query: |-
+        {{- range .spec.template.spec.networks }}
+        {{- with index . "multus" }}
+        {{- if not (contains "/" .networkName) }}
+        k8s:NetworkAttachmentDefinition.k8s.cni.cncf.io:{"namespace":"{{$.metadata.namespace}}","name":"{{.networkName}}"}
+        {{- end }}
+        {{- end }}
+        {{- end }}
 
   - name: VmiToNetAttachDef
     start:
@@ -366,5 +450,215 @@ rules:
         {{- if not (contains "/" .networkName) }}
         k8s:NetworkAttachmentDefinition.k8s.cni.cncf.io:{"namespace":"{{$.metadata.namespace}}","name":"{{.networkName}}"}
         {{- end }}
+        {{- end }}
+        {{- end }}
+
+  # ─── VM / VMI → Secret (cloud-init, sysprep, access credentials) ──────────
+  # Secrets are referenced from multiple volume types and accessCredentials.
+  # A missing or invalid Secret commonly causes VM boot failures.
+
+  - name: VmToSecret
+    start:
+      domain: k8s
+      classes: [VirtualMachine.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [Secret]
+    result:
+      query: |-
+        {{- range .spec.template.spec.volumes }}
+        {{- with index . "secret" }}
+        k8s:Secret:{"namespace":"{{$.metadata.namespace}}","name":"{{.secretName}}"}
+        {{- end }}
+        {{- with index . "cloudInitNoCloud" }}
+        {{- with index . "secretRef" }}
+        k8s:Secret:{"namespace":"{{$.metadata.namespace}}","name":"{{.name}}"}
+        {{- end }}
+        {{- with index . "networkDataSecretRef" }}
+        k8s:Secret:{"namespace":"{{$.metadata.namespace}}","name":"{{.name}}"}
+        {{- end }}
+        {{- end }}
+        {{- with index . "cloudInitConfigDrive" }}
+        {{- with index . "secretRef" }}
+        k8s:Secret:{"namespace":"{{$.metadata.namespace}}","name":"{{.name}}"}
+        {{- end }}
+        {{- with index . "networkDataSecretRef" }}
+        k8s:Secret:{"namespace":"{{$.metadata.namespace}}","name":"{{.name}}"}
+        {{- end }}
+        {{- end }}
+        {{- with index . "sysprep" }}
+        {{- with index . "secret" }}
+        k8s:Secret:{"namespace":"{{$.metadata.namespace}}","name":"{{.name}}"}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- range index .spec.template.spec "accessCredentials" }}
+        {{- with index . "sshPublicKey" }}
+        {{- with index .source "secret" }}
+        k8s:Secret:{"namespace":"{{$.metadata.namespace}}","name":"{{.secretName}}"}
+        {{- end }}
+        {{- end }}
+        {{- with index . "userPassword" }}
+        {{- with index .source "secret" }}
+        k8s:Secret:{"namespace":"{{$.metadata.namespace}}","name":"{{.secretName}}"}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+
+  - name: VmiToSecret
+    start:
+      domain: k8s
+      classes: [VirtualMachineInstance.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [Secret]
+    result:
+      query: |-
+        {{- range .spec.volumes }}
+        {{- with index . "secret" }}
+        k8s:Secret:{"namespace":"{{$.metadata.namespace}}","name":"{{.secretName}}"}
+        {{- end }}
+        {{- with index . "cloudInitNoCloud" }}
+        {{- with index . "secretRef" }}
+        k8s:Secret:{"namespace":"{{$.metadata.namespace}}","name":"{{.name}}"}
+        {{- end }}
+        {{- with index . "networkDataSecretRef" }}
+        k8s:Secret:{"namespace":"{{$.metadata.namespace}}","name":"{{.name}}"}
+        {{- end }}
+        {{- end }}
+        {{- with index . "cloudInitConfigDrive" }}
+        {{- with index . "secretRef" }}
+        k8s:Secret:{"namespace":"{{$.metadata.namespace}}","name":"{{.name}}"}
+        {{- end }}
+        {{- with index . "networkDataSecretRef" }}
+        k8s:Secret:{"namespace":"{{$.metadata.namespace}}","name":"{{.name}}"}
+        {{- end }}
+        {{- end }}
+        {{- with index . "sysprep" }}
+        {{- with index . "secret" }}
+        k8s:Secret:{"namespace":"{{$.metadata.namespace}}","name":"{{.name}}"}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- range index .spec "accessCredentials" }}
+        {{- with index . "sshPublicKey" }}
+        {{- with index .source "secret" }}
+        k8s:Secret:{"namespace":"{{$.metadata.namespace}}","name":"{{.secretName}}"}
+        {{- end }}
+        {{- end }}
+        {{- with index . "userPassword" }}
+        {{- with index .source "secret" }}
+        k8s:Secret:{"namespace":"{{$.metadata.namespace}}","name":"{{.secretName}}"}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+
+  # ─── VM / VMI → ConfigMap (sysprep, volume mounts) ────────────────────────
+
+  - name: VmToConfigMap
+    start:
+      domain: k8s
+      classes: [VirtualMachine.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [ConfigMap]
+    result:
+      query: |-
+        {{- range .spec.template.spec.volumes }}
+        {{- with index . "configMap" }}
+        k8s:ConfigMap:{"namespace":"{{$.metadata.namespace}}","name":"{{.name}}"}
+        {{- end }}
+        {{- with index . "sysprep" }}
+        {{- with index . "configMap" }}
+        k8s:ConfigMap:{"namespace":"{{$.metadata.namespace}}","name":"{{.name}}"}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+
+  - name: VmiToConfigMap
+    start:
+      domain: k8s
+      classes: [VirtualMachineInstance.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [ConfigMap]
+    result:
+      query: |-
+        {{- range .spec.volumes }}
+        {{- with index . "configMap" }}
+        k8s:ConfigMap:{"namespace":"{{$.metadata.namespace}}","name":"{{.name}}"}
+        {{- end }}
+        {{- with index . "sysprep" }}
+        {{- with index . "configMap" }}
+        k8s:ConfigMap:{"namespace":"{{$.metadata.namespace}}","name":"{{.name}}"}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+
+  # ─── VM / VMI → ServiceAccount ────────────────────────────────────────────
+
+  - name: VmToServiceAccount
+    start:
+      domain: k8s
+      classes: [VirtualMachine.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [ServiceAccount]
+    result:
+      query: |-
+        {{- range .spec.template.spec.volumes }}
+        {{- with index . "serviceAccount" }}
+        k8s:ServiceAccount:{"namespace":"{{$.metadata.namespace}}","name":"{{.serviceAccountName}}"}
+        {{- end }}
+        {{- end }}
+
+  - name: VmiToServiceAccount
+    start:
+      domain: k8s
+      classes: [VirtualMachineInstance.kubevirt.io]
+    goal:
+      domain: k8s
+      classes: [ServiceAccount]
+    result:
+      query: |-
+        {{- range .spec.volumes }}
+        {{- with index . "serviceAccount" }}
+        k8s:ServiceAccount:{"namespace":"{{$.metadata.namespace}}","name":"{{.serviceAccountName}}"}
+        {{- end }}
+        {{- end }}
+
+  # ─── VM → Instancetype / Preference (config resolution) ───────────────────
+  # VMs reference instancetypes and preferences by name + optional kind.
+  # Default kind is the cluster-scoped variant.
+
+  - name: VmToInstancetype
+    start:
+      domain: k8s
+      classes: [VirtualMachine.kubevirt.io]
+    goal:
+      domain: k8s
+    result:
+      query: |-
+        {{- with index .spec "instancetype" }}
+        {{- if eq (index . "kind") "VirtualMachineInstancetype" }}
+        k8s:VirtualMachineInstancetype.instancetype.kubevirt.io:{"namespace":"{{$.metadata.namespace}}","name":"{{.name}}"}
+        {{- else }}
+        k8s:VirtualMachineClusterInstancetype.instancetype.kubevirt.io:{"name":"{{.name}}"}
+        {{- end }}
+        {{- end }}
+
+  - name: VmToPreference
+    start:
+      domain: k8s
+      classes: [VirtualMachine.kubevirt.io]
+    goal:
+      domain: k8s
+    result:
+      query: |-
+        {{- with index .spec "preference" }}
+        {{- if eq (index . "kind") "VirtualMachinePreference" }}
+        k8s:VirtualMachinePreference.instancetype.kubevirt.io:{"namespace":"{{$.metadata.namespace}}","name":"{{.name}}"}
+        {{- else }}
+        k8s:VirtualMachineClusterPreference.instancetype.kubevirt.io:{"name":"{{.name}}"}
         {{- end }}
         {{- end }}

--- a/etc/korrel8r/rules/kubevirt_test.go
+++ b/etc/korrel8r/rules/kubevirt_test.go
@@ -35,14 +35,56 @@ func TestKubevirtRules(t *testing.T) {
 			start: newK8s("VirtualMachine.kubevirt.io", "vm-ns", "vm-name", k8s.Object{
 				"spec": k8s.Object{
 					"dataVolumeTemplates": []k8s.Object{
-						{"metadata": k8s.Object{"name": "dv1"}},
-						{"metadata": k8s.Object{"name": "dv2"}},
+						{"metadata": k8s.Object{"name": "template-dv"}},
+					},
+					"template": k8s.Object{
+						"spec": k8s.Object{
+							"volumes": []k8s.Object{
+								{"name": "rootdisk", "dataVolume": k8s.Object{"name": "preexisting-dv"}},
+								{"name": "datadisk", "persistentVolumeClaim": k8s.Object{"claimName": "direct-pvc"}},
+							},
+						},
 					},
 				},
 			}),
 			want: []string{
-				`k8s:PersistentVolumeClaim.v1:{"namespace":"vm-ns","name":"dv1"}`,
-				`k8s:PersistentVolumeClaim.v1:{"namespace":"vm-ns","name":"dv2"}`,
+				`k8s:PersistentVolumeClaim.v1:{"namespace":"vm-ns","name":"template-dv"}`,
+				`k8s:PersistentVolumeClaim.v1:{"namespace":"vm-ns","name":"preexisting-dv"}`,
+				`k8s:PersistentVolumeClaim.v1:{"namespace":"vm-ns","name":"direct-pvc"}`,
+			},
+		},
+		{
+			rule: "VmToPVC",
+			start: newK8s("VirtualMachine.kubevirt.io", "vm-ns", "vm-name", k8s.Object{
+				"spec": k8s.Object{
+					"template": k8s.Object{
+						"spec": k8s.Object{
+							"volumes": []k8s.Object{
+								{"name": "ephemeral-vol", "ephemeral": k8s.Object{"persistentVolumeClaim": k8s.Object{"claimName": "eph-pvc"}}},
+								{"name": "memdump", "memoryDump": k8s.Object{"claimName": "dump-pvc"}},
+							},
+						},
+					},
+				},
+			}),
+			want: []string{
+				`k8s:PersistentVolumeClaim.v1:{"namespace":"vm-ns","name":"eph-pvc"}`,
+				`k8s:PersistentVolumeClaim.v1:{"namespace":"vm-ns","name":"dump-pvc"}`,
+			},
+		},
+		{
+			rule: "VmiToPVC",
+			start: newK8s("VirtualMachineInstance.kubevirt.io", "vm-ns", "my-vmi", k8s.Object{
+				"spec": k8s.Object{
+					"volumes": []k8s.Object{
+						{"name": "ephemeral-vol", "ephemeral": k8s.Object{"persistentVolumeClaim": k8s.Object{"claimName": "eph-pvc"}}},
+						{"name": "memdump", "memoryDump": k8s.Object{"claimName": "dump-pvc"}},
+					},
+				},
+			}),
+			want: []string{
+				`k8s:PersistentVolumeClaim.v1:{"namespace":"vm-ns","name":"eph-pvc"}`,
+				`k8s:PersistentVolumeClaim.v1:{"namespace":"vm-ns","name":"dump-pvc"}`,
 			},
 		},
 		{
@@ -105,6 +147,33 @@ func TestKubevirtRules(t *testing.T) {
 			want:  []string{`k8s:VirtualMachineInstanceMigration.v1.kubevirt.io:{"namespace":"vm-ns","labels":{"kubevirt.io/vmi-name":"my-vmi"}}`},
 		},
 		{
+			rule: "VmiToPVC",
+			start: newK8s("VirtualMachineInstance.kubevirt.io", "vm-ns", "my-vmi", k8s.Object{
+				"spec": k8s.Object{
+					"volumes": []k8s.Object{
+						{"name": "rootdisk", "dataVolume": k8s.Object{"name": "my-dv"}},
+						{"name": "datadisk", "persistentVolumeClaim": k8s.Object{"claimName": "my-pvc"}},
+					},
+				},
+			}),
+			want: []string{
+				`k8s:PersistentVolumeClaim.v1:{"namespace":"vm-ns","name":"my-dv"}`,
+				`k8s:PersistentVolumeClaim.v1:{"namespace":"vm-ns","name":"my-pvc"}`,
+			},
+		},
+		{
+			rule: "VmiToDataVolume",
+			start: newK8s("VirtualMachineInstance.kubevirt.io", "vm-ns", "my-vmi", k8s.Object{
+				"spec": k8s.Object{
+					"volumes": []k8s.Object{
+						{"name": "rootdisk", "dataVolume": k8s.Object{"name": "my-dv"}},
+						{"name": "datadisk", "persistentVolumeClaim": k8s.Object{"claimName": "my-pvc"}},
+					},
+				},
+			}),
+			want: []string{`k8s:DataVolume.v1beta1.cdi.kubevirt.io:{"namespace":"vm-ns","name":"my-dv"}`},
+		},
+		{
 			rule:  "DataVolumeToPVC",
 			start: newK8s("DataVolume.cdi.kubevirt.io", "vm-ns", "my-dv", nil),
 			want:  []string{`k8s:PersistentVolumeClaim.v1:{"namespace":"vm-ns","name":"my-dv"}`},
@@ -114,11 +183,21 @@ func TestKubevirtRules(t *testing.T) {
 			start: newK8s("VirtualMachine.kubevirt.io", "vm-ns", "my-vm", k8s.Object{
 				"spec": k8s.Object{
 					"dataVolumeTemplates": []k8s.Object{
-						{"metadata": k8s.Object{"name": "dv1"}},
+						{"metadata": k8s.Object{"name": "template-dv"}},
+					},
+					"template": k8s.Object{
+						"spec": k8s.Object{
+							"volumes": []k8s.Object{
+								{"name": "extra", "dataVolume": k8s.Object{"name": "preexisting-dv"}},
+							},
+						},
 					},
 				},
 			}),
-			want: []string{`k8s:DataVolume.v1beta1.cdi.kubevirt.io:{"namespace":"vm-ns","name":"dv1"}`},
+			want: []string{
+				`k8s:DataVolume.v1beta1.cdi.kubevirt.io:{"namespace":"vm-ns","name":"template-dv"}`,
+				`k8s:DataVolume.v1beta1.cdi.kubevirt.io:{"namespace":"vm-ns","name":"preexisting-dv"}`,
+			},
 		},
 		{
 			rule: "VmSnapshotToVm",
@@ -193,6 +272,156 @@ func TestKubevirtRules(t *testing.T) {
 			rule:  "DataVolumeToImporterPod",
 			start: newK8s("DataVolume.cdi.kubevirt.io", "vm-ns", "my-dv", nil),
 			want:  []string{`k8s:Pod.v1:{"namespace":"vm-ns","labels":{"cdi.kubevirt.io/storage.import.importPvcName":"my-dv"}}`},
+		},
+		{
+			rule: "VmToSecret",
+			start: newK8s("VirtualMachine.kubevirt.io", "vm-ns", "my-vm", k8s.Object{
+				"spec": k8s.Object{
+					"template": k8s.Object{
+						"spec": k8s.Object{
+							"volumes": []k8s.Object{
+								{"name": "cloudinit", "cloudInitNoCloud": k8s.Object{"secretRef": k8s.Object{"name": "ci-secret"}}},
+								{"name": "sysprep-vol", "sysprep": k8s.Object{"secret": k8s.Object{"name": "sysprep-secret"}}},
+							},
+							"accessCredentials": []k8s.Object{
+								{"sshPublicKey": k8s.Object{"source": k8s.Object{"secret": k8s.Object{"secretName": "ssh-key"}}}},
+							},
+						},
+					},
+				},
+			}),
+			want: []string{
+				`k8s:Secret.v1:{"namespace":"vm-ns","name":"ci-secret"}`,
+				`k8s:Secret.v1:{"namespace":"vm-ns","name":"sysprep-secret"}`,
+				`k8s:Secret.v1:{"namespace":"vm-ns","name":"ssh-key"}`,
+			},
+		},
+		{
+			rule: "VmiToSecret",
+			start: newK8s("VirtualMachineInstance.kubevirt.io", "vm-ns", "my-vmi", k8s.Object{
+				"spec": k8s.Object{
+					"volumes": []k8s.Object{
+						{"name": "secret-vol", "secret": k8s.Object{"secretName": "my-secret"}},
+						{"name": "rootdisk", "dataVolume": k8s.Object{"name": "dv1"}},
+					},
+				},
+			}),
+			want: []string{`k8s:Secret.v1:{"namespace":"vm-ns","name":"my-secret"}`},
+		},
+		{
+			rule: "VmToConfigMap",
+			start: newK8s("VirtualMachine.kubevirt.io", "vm-ns", "my-vm", k8s.Object{
+				"spec": k8s.Object{
+					"template": k8s.Object{
+						"spec": k8s.Object{
+							"volumes": []k8s.Object{
+								{"name": "cm-vol", "configMap": k8s.Object{"name": "my-cm"}},
+							},
+						},
+					},
+				},
+			}),
+			want: []string{`k8s:ConfigMap.v1:{"namespace":"vm-ns","name":"my-cm"}`},
+		},
+		{
+			rule: "VmiToConfigMap",
+			start: newK8s("VirtualMachineInstance.kubevirt.io", "vm-ns", "my-vmi", k8s.Object{
+				"spec": k8s.Object{
+					"volumes": []k8s.Object{
+						{"name": "sysprep-vol", "sysprep": k8s.Object{"configMap": k8s.Object{"name": "sysprep-cm"}}},
+					},
+				},
+			}),
+			want: []string{`k8s:ConfigMap.v1:{"namespace":"vm-ns","name":"sysprep-cm"}`},
+		},
+		{
+			rule: "VmToServiceAccount",
+			start: newK8s("VirtualMachine.kubevirt.io", "vm-ns", "my-vm", k8s.Object{
+				"spec": k8s.Object{
+					"template": k8s.Object{
+						"spec": k8s.Object{
+							"volumes": []k8s.Object{
+								{"name": "sa-vol", "serviceAccount": k8s.Object{"serviceAccountName": "my-sa"}},
+							},
+						},
+					},
+				},
+			}),
+			want: []string{`k8s:ServiceAccount.v1:{"namespace":"vm-ns","name":"my-sa"}`},
+		},
+		{
+			rule: "VmiToServiceAccount",
+			start: newK8s("VirtualMachineInstance.kubevirt.io", "vm-ns", "my-vmi", k8s.Object{
+				"spec": k8s.Object{
+					"volumes": []k8s.Object{
+						{"name": "sa-vol", "serviceAccount": k8s.Object{"serviceAccountName": "my-sa"}},
+					},
+				},
+			}),
+			want: []string{`k8s:ServiceAccount.v1:{"namespace":"vm-ns","name":"my-sa"}`},
+		},
+		{
+			rule: "VmToInstancetype",
+			start: newK8s("VirtualMachine.kubevirt.io", "vm-ns", "my-vm", k8s.Object{
+				"spec": k8s.Object{
+					"instancetype": k8s.Object{
+						"name": "u1.medium",
+						"kind": "VirtualMachineClusterInstancetype",
+					},
+				},
+			}),
+			want: []string{`k8s:VirtualMachineClusterInstancetype.v1beta1.instancetype.kubevirt.io:{"name":"u1.medium"}`},
+		},
+		{
+			rule: "VmToInstancetype",
+			start: newK8s("VirtualMachine.kubevirt.io", "vm-ns", "my-vm", k8s.Object{
+				"spec": k8s.Object{
+					"instancetype": k8s.Object{
+						"name": "custom-type",
+						"kind": "VirtualMachineInstancetype",
+					},
+				},
+			}),
+			want: []string{`k8s:VirtualMachineInstancetype.v1beta1.instancetype.kubevirt.io:{"namespace":"vm-ns","name":"custom-type"}`},
+		},
+		{
+			rule: "VmToPreference",
+			start: newK8s("VirtualMachine.kubevirt.io", "vm-ns", "my-vm", k8s.Object{
+				"spec": k8s.Object{
+					"preference": k8s.Object{
+						"name": "rhel9",
+					},
+				},
+			}),
+			want: []string{`k8s:VirtualMachineClusterPreference.v1beta1.instancetype.kubevirt.io:{"name":"rhel9"}`},
+		},
+		{
+			rule: "VmToPreference",
+			start: newK8s("VirtualMachine.kubevirt.io", "vm-ns", "my-vm", k8s.Object{
+				"spec": k8s.Object{
+					"preference": k8s.Object{
+						"name": "custom-pref",
+						"kind": "VirtualMachinePreference",
+					},
+				},
+			}),
+			want: []string{`k8s:VirtualMachinePreference.v1beta1.instancetype.kubevirt.io:{"namespace":"vm-ns","name":"custom-pref"}`},
+		},
+		{
+			rule: "VmToNetAttachDef",
+			start: newK8s("VirtualMachine.kubevirt.io", "vm-ns", "my-vm", k8s.Object{
+				"spec": k8s.Object{
+					"template": k8s.Object{
+						"spec": k8s.Object{
+							"networks": []k8s.Object{
+								{"name": "default", "pod": k8s.Object{}},
+								{"name": "net1", "multus": k8s.Object{"networkName": "my-nad"}},
+							},
+						},
+					},
+				},
+			}),
+			want: []string{`k8s:NetworkAttachmentDefinition.v1.k8s.cni.cncf.io:{"namespace":"vm-ns","name":"my-nad"}`},
 		},
 		{
 			rule: "VmiToNetAttachDef",

--- a/etc/korrel8r/rules/rules_test.go
+++ b/etc/korrel8r/rules/rules_test.go
@@ -82,6 +82,15 @@ var customResourcesForTests = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "instancetype.kubevirt.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{Kind: "VirtualMachineInstancetype", Namespaced: true},
+			{Kind: "VirtualMachineClusterInstancetype", Namespaced: false},
+			{Kind: "VirtualMachinePreference", Namespaced: true},
+			{Kind: "VirtualMachineClusterPreference", Namespaced: false},
+		},
+	},
+	{
 		GroupVersion: "config.openshift.io/v1",
 		APIResources: []metav1.APIResource{
 			{Kind: "Node", Namespaced: false},


### PR DESCRIPTION
## Summary

Enable correlating infrastructure events (storage, network, config) with the VMs that consume them by closing gaps in the KubeVirt rule graph.

### New rules

| Rule | From | To | Traversal path |
|------|------|----|----------------|
| **VmiToPVC** | VMI | PVC | `spec.volumes[]` (persistentVolumeClaim, dataVolume, ephemeral, memoryDump) |
| **VmiToDataVolume** | VMI | DataVolume | `spec.volumes[].dataVolume` |
| **VmToNetAttachDef** | VM | NAD | `spec.template.spec.networks[].multus` |
| **VmToSecret** | VM | Secret | volumes (secret, cloudInit*, sysprep) + accessCredentials |
| **VmiToSecret** | VMI | Secret | volumes (secret, cloudInit*, sysprep) + accessCredentials |
| **VmToConfigMap** | VM | ConfigMap | volumes (configMap, sysprep) |
| **VmiToConfigMap** | VMI | ConfigMap | volumes (configMap, sysprep) |
| **VmToServiceAccount** | VM | ServiceAccount | volumes (serviceAccount) |
| **VmiToServiceAccount** | VMI | ServiceAccount | volumes (serviceAccount) |
| **VmToInstancetype** | VM | Instancetype/ClusterInstancetype | `spec.instancetype` (kind-aware) |
| **VmToPreference** | VM | Preference/ClusterPreference | `spec.preference` (kind-aware) |

### Enhanced existing rules

- **VmToPVC**: extended to traverse `spec.template.spec.volumes[]` for direct PVC, DataVolume, ephemeral, and memoryDump references (previously only checked `dataVolumeTemplates`)
- **VmToDataVolume**: extended to traverse `spec.template.spec.volumes[]` for pre-existing DataVolume references
- **VmToPVC / VmToDataVolume**: fixed latent `missingkey=error` bug by using `index` for optional `spec.dataVolumeTemplates`

### Known limitations

- **DataVolume → VM**: the generic `DependentToOwner` rule only covers DataVolumes created via `spec.dataVolumeTemplates` (which have ownerReferences set by KubeVirt). Pre-existing DataVolumes referenced by name in `spec.template.spec.volumes[].dataVolume` do **not** have ownerReferences pointing back to the VM, so the DV → VM direction is one-way only. A reverse lookup would require searching all VMs in the namespace, which korrel8r rules cannot express (they operate on a single object's fields).
- **Cross-namespace NADs**: `VmToNetAttachDef` / `VmiToNetAttachDef` only handle same-namespace NADs (format `"name"`). The cross-namespace format (`"namespace/name"`) requires string splitting which Go templates cannot do without a custom function.

## Test plan

- [x] Added test cases for all new rules
- [x] Added test cases for ephemeral/memoryDump PVC types
- [x] Added VmToInstancetype tests for both namespaced and cluster-scoped variants
- [x] Added VmToPreference tests for both namespaced (explicit kind) and cluster-scoped (default)
- [x] Registered `instancetype.kubevirt.io/v1beta1` CRDs in test setup
- [x] All existing tests continue to pass