### PR TITLE
perf: reduce copying of graph structs

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -129,7 +129,7 @@ func (e *Engine) StatusRulesFor(c korrel8r.Class) []status.Rule { return e.statu
 
 // Graph returns the read-only topology graph. Callers use GoalPaths/Neighbors/Select
 // to create mutable subgraphs for traversal.
-func (e *Engine) Graph() *graph.Graph { return e.data.TopoGraph() }
+func (e *Engine) Graph() *graph.Graph { return e.data.SharedGraph() }
 
 // Get results for query from all stores for the query domain.
 func (e *Engine) Get(ctx context.Context, query korrel8r.Query, constraint *korrel8r.Constraint, result korrel8r.Appender) (err error) {

--- a/pkg/engine/traverse/traverse.go
+++ b/pkg/engine/traverse/traverse.go
@@ -11,11 +11,13 @@
 //     b. New objects are added to the target node, applying correlation rules immediately.
 //     c. Resulting queries are deduplicated and sent back to the channel.
 //  4. Traversal completes when all in-flight work is done (tracked by sync.WaitGroup).
-//  5. Empty nodes and lines are pruned from the result graph.
+//  5. A result graph is built from only the nodes and lines that produced results.
 package traverse
 
 import (
 	"context"
+
+	"math"
 	"runtime"
 	"sync"
 
@@ -23,31 +25,89 @@ import (
 	"github.com/korrel8r/korrel8r/pkg/engine"
 	"github.com/korrel8r/korrel8r/pkg/graph"
 	"github.com/korrel8r/korrel8r/pkg/korrel8r"
+	"github.com/korrel8r/korrel8r/pkg/result"
 	"github.com/korrel8r/korrel8r/pkg/unique"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+	"gonum.org/v1/gonum/graph/multi"
+	"gonum.org/v1/gonum/graph/path"
+	gonumTraverse "gonum.org/v1/gonum/graph/traverse"
+
+	gonumGraph "gonum.org/v1/gonum/graph"
 )
 
 // Goals traverses all paths from start objects to all goal classes.
 func Goals(ctx context.Context, e *engine.Engine, start Start, goals []korrel8r.Class) (*graph.Graph, error) {
 	log.V(2).Info("Goal directed search", "start", start, "goals", goals, "constraint", start.Constraint)
-	g, err := e.Graph().GoalPaths(start.Class, goals)
+	shared := e.Graph()
+	scope, err := goalScope(shared, start.Class, goals)
 	if err != nil {
 		return nil, err
 	}
-	g, err = newTraverser(e, g, start.Constraint, -1).run(ctx, start)
+	g, err := newTraverser(e, shared.Data, scope, start.Constraint, -1).run(ctx, start)
+	if err != nil {
+		return nil, err
+	}
+	// Remove dead-end paths that don't reach a goal.
 	g.RemoveEmptyGoalPaths(goals)
-	return g, err
+	return g, nil
 }
 
 // Neighbors traverses to all neighbors of the start objects, traversing links up to the given depth.
 func Neighbors(ctx context.Context, e *engine.Engine, start Start, depth int) (*graph.Graph, error) {
 	log.V(2).Info("Neighbourhood search", "start", start, "depth", depth, "constraint", start.Constraint)
-	g, err := e.Graph().Neighbors(start.Class, depth)
+	shared := e.Graph()
+	scope, err := neighborScope(shared, start.Class, depth)
 	if err != nil {
 		return nil, err
 	}
-	return newTraverser(e, g, start.Constraint, depth).run(ctx, start)
+	return newTraverser(e, shared.Data, scope, start.Constraint, depth).run(ctx, start)
+}
+
+// neighborScope returns the lines reachable within maxDepth BFS hops from start.
+func neighborScope(shared *graph.Graph, start korrel8r.Class, maxDepth int) ([]*graph.Line, error) {
+	u, err := shared.NodeForErr(start)
+	if err != nil {
+		return nil, err
+	}
+	var lines []*graph.Line
+	depth := 0
+	bf := gonumTraverse.BreadthFirst{
+		Traverse: func(e gonumGraph.Edge) bool {
+			ok := depth < maxDepth
+			if ok {
+				graph.EdgeFor(e).EachLine(func(l *graph.Line) { lines = append(lines, l) })
+			}
+			return ok
+		},
+	}
+	_ = bf.Walk(shared, u, func(n gonumGraph.Node, d int) bool { depth = d; return d > maxDepth })
+	return lines, nil
+}
+
+// goalScope returns the lines on shortest/near-shortest paths from start to each goal.
+func goalScope(shared *graph.Graph, start korrel8r.Class, goals []korrel8r.Class) ([]*graph.Line, error) {
+	u, err := shared.NodeForErr(start)
+	if err != nil {
+		return nil, err
+	}
+	var lines []*graph.Line
+	for _, goal := range goals {
+		v, err := shared.NodeForErr(goal)
+		if err != nil {
+			return nil, err
+		}
+		paths := path.YenKShortestPaths(shared, math.MaxInt, 1, u, v)
+		for _, p := range paths {
+			for i := 1; i < len(p); i++ {
+				ls := shared.Lines(p[i-1].ID(), p[i].ID())
+				for ls.Next() {
+					lines = append(lines, ls.Line().(*graph.Line))
+				}
+			}
+		}
+	}
+	return lines, nil
 }
 
 // Start point information for graph traversal.
@@ -63,7 +123,8 @@ var log = logging.Log()
 // queryLine is a query, the graph line that generated it, and its traversal depth.
 type queryLine struct {
 	Query korrel8r.Query
-	Line  *graph.Line
+	Line  *graph.Line // immutable line (for Rule, String, metric attrs)
+	key   lineKey     // overlay state key
 	depth int
 }
 
@@ -80,11 +141,13 @@ type lineKey struct {
 	rule        korrel8r.Rule
 }
 
-// node wraps a graph.Node with a mutex for concurrent access.
+// node holds mutable per-class state for the traversal overlay.
 type node struct {
-	mu sync.Mutex
-	*graph.Node
-	processed int // count of Result objects already rule-applied
+	mu        sync.Mutex
+	class     korrel8r.Class
+	result    result.Result
+	queries   graph.Queries
+	processed int // count of result objects already rule-applied
 }
 
 // workQueue is an unbounded, mutex-protected FIFO queue.
@@ -132,73 +195,83 @@ func (q *workQueue) close() {
 
 type traverser struct {
 	engine     *engine.Engine
-	graph      *graph.Graph
+	data       *graph.Data
 	constraint *korrel8r.Constraint
 	maxDepth   int // -1 for unlimited
 
 	// Read-only after init
 	nodes     map[korrel8r.Class]*node
 	rules     map[korrel8r.Class]unique.Set[korrel8r.Rule]
-	lines     map[lineKey]*graph.Line
+	lines     map[lineKey]*graph.Line // immutable lines (for Rule access)
 	ruleAttrs map[korrel8r.Rule]metric.MeasurementOption
 
 	// Concurrent state
-	work   *workQueue
-	wg     sync.WaitGroup
-	seenMu sync.Mutex
-	seen   map[korrel8r.Query]struct{}
-	lineMu sync.Mutex
+	lineQueries map[lineKey]graph.Queries // overlay: mutable line queries
+	work        *workQueue
+	wg          sync.WaitGroup
+	seenMu      sync.Mutex
+	seen        map[korrel8r.Query]struct{}
+	lineMu      sync.Mutex
 }
 
-func newTraverser(e *engine.Engine, g *graph.Graph, c *korrel8r.Constraint, maxDepth int) *traverser {
+func newTraverser(e *engine.Engine, data *graph.Data, scopeLines []*graph.Line, c *korrel8r.Constraint, maxDepth int) *traverser {
 	t := &traverser{
-		engine:     e,
-		graph:      g,
-		constraint: c,
-		maxDepth:   maxDepth,
-		nodes:      map[korrel8r.Class]*node{},
-		rules:      map[korrel8r.Class]unique.Set[korrel8r.Rule]{},
-		lines:      map[lineKey]*graph.Line{},
-		ruleAttrs:  map[korrel8r.Rule]metric.MeasurementOption{},
-		work:       newWorkQueue(),
-		seen:       map[korrel8r.Query]struct{}{},
+		engine:      e,
+		data:        data,
+		constraint:  c,
+		maxDepth:    maxDepth,
+		nodes:       map[korrel8r.Class]*node{},
+		rules:       map[korrel8r.Class]unique.Set[korrel8r.Rule]{},
+		lines:       map[lineKey]*graph.Line{},
+		lineQueries: map[lineKey]graph.Queries{},
+		ruleAttrs:   map[korrel8r.Rule]metric.MeasurementOption{},
+		work:        newWorkQueue(),
+		seen:        map[korrel8r.Query]struct{}{},
 	}
 
-	g.EachLine(func(l *graph.Line) {
-		t.getOrCreateNode(l.Start())
-		t.getOrCreateNode(l.Goal())
+	for _, l := range scopeLines {
 		startClass := l.Start().Class
+		goalClass := l.Goal().Class
+		t.getOrCreateNode(startClass)
+		t.getOrCreateNode(goalClass)
 		if t.rules[startClass] == nil {
 			t.rules[startClass] = unique.NewSet[korrel8r.Rule]()
 		}
 		t.rules[startClass].Add(l.Rule)
-		t.lines[lineKey{start: startClass, rule: l.Rule, goal: l.Goal().Class}] = l
+		key := lineKey{start: startClass, rule: l.Rule, goal: goalClass}
+		t.lines[key] = l
+		if _, ok := t.lineQueries[key]; !ok {
+			t.lineQueries[key] = graph.Queries{}
+		}
 		if _, ok := t.ruleAttrs[l.Rule]; !ok {
 			t.ruleAttrs[l.Rule] = metric.WithAttributes(
 				attribute.String("rule", l.Rule.Name()),
 				attribute.String("start", startClass.String()))
 		}
-	})
+	}
 
 	return t
 }
 
-func (t *traverser) getOrCreateNode(gn *graph.Node) *node {
-	n := t.nodes[gn.Class]
+func (t *traverser) getOrCreateNode(class korrel8r.Class) *node {
+	n := t.nodes[class]
 	if n == nil {
-		n = &node{Node: gn}
-		t.nodes[gn.Class] = n
+		n = &node{
+			class:   class,
+			result:  result.New(class),
+			queries: graph.Queries{},
+		}
+		t.nodes[class] = n
 	}
 	return n
 }
 
 // run launches the worker pool, primes start data, and waits for completion.
 func (t *traverser) run(ctx context.Context, start Start) (*graph.Graph, error) {
-	startGraphNode, err := t.graph.NodeForErr(start.Class)
-	if err != nil {
-		return nil, err
+	startNode := t.nodes[start.Class]
+	if startNode == nil {
+		startNode = t.getOrCreateNode(start.Class)
 	}
-	startNode := t.getOrCreateNode(startGraphNode)
 
 	// Launch worker pool — workers block on the empty queue until work arrives.
 	numWorkers := runtime.GOMAXPROCS(0)
@@ -215,7 +288,7 @@ func (t *traverser) run(ctx context.Context, start Start) (*graph.Graph, error) 
 	t.wg.Add(1)
 
 	startNode.mu.Lock()
-	startNode.Result.Append(start.Objects...)
+	startNode.result.Append(start.Objects...)
 	startNode.mu.Unlock()
 
 	for _, q := range start.Queries {
@@ -229,8 +302,49 @@ func (t *traverser) run(ctx context.Context, start Start) (*graph.Graph, error) 
 	t.work.close()
 	workerWg.Wait()
 
-	t.graph.RemoveEmpty()
-	return t.graph, ctx.Err()
+	return t.buildGraph(), ctx.Err()
+}
+
+// buildGraph creates a result graph containing only nodes and lines that produced results.
+func (t *traverser) buildGraph() *graph.Graph {
+	g := graph.New(t.data)
+	nodeMap := map[korrel8r.Class]*graph.Node{}
+	for _, n := range t.nodes {
+		if len(n.result.List()) == 0 {
+			continue
+		}
+		dn := t.data.NodeFor(n.class)
+		if dn == nil {
+			continue
+		}
+		gn := &graph.Node{
+			Node:    dn.Node,
+			Class:   n.class,
+			Attrs:   graph.Attrs{},
+			Result:  n.result,
+			Queries: n.queries,
+		}
+		g.AddNode(gn)
+		nodeMap[n.class] = gn
+	}
+	for key, queries := range t.lineQueries {
+		if queries.Total() == 0 {
+			continue
+		}
+		from, to := nodeMap[key.start], nodeMap[key.goal]
+		if from == nil || to == nil {
+			continue
+		}
+		topoLine := t.lines[key]
+		l := &graph.Line{
+			Line:    multi.Line{F: from, T: to, UID: topoLine.UID},
+			Rule:    topoLine.Rule,
+			Attrs:   graph.Attrs{},
+			Queries: queries,
+		}
+		g.AddLine(l)
+	}
+	return g
 }
 
 // dedupAndSend checks depth and query dedup, then adds to the work queue.
@@ -288,18 +402,18 @@ func (t *traverser) handleQuery(ctx context.Context, ql queryLine) {
 	// 2. A concurrent append may grow the backing array, but the old array stays valid.
 	// 3. We only read indices < our captured len, so concurrent writes at higher indices don't matter.
 	n.mu.Lock()
-	before := len(n.Result.List())
+	before := len(n.result.List())
 	for _, o := range results {
-		n.Result.Add(o)
+		n.result.Add(o)
 	}
-	resultList := n.Result.List()
+	resultList := n.result.List()
 	resultCount := len(resultList) - before
-	n.Queries.Set(ql.Query, resultCount)
+	n.queries.Set(ql.Query, resultCount)
 	n.mu.Unlock()
 
 	if ql.Line != nil {
 		t.lineMu.Lock()
-		ql.Line.Queries.Set(ql.Query, resultCount)
+		t.lineQueries[ql.key].Set(ql.Query, resultCount)
 		t.lineMu.Unlock()
 	}
 
@@ -317,7 +431,7 @@ func (t *traverser) handleQuery(ctx context.Context, ql queryLine) {
 		}
 		if len(statusCounts) > 0 {
 			n.mu.Lock()
-			n.Queries.AddStatuses(ql.Query, statusCounts)
+			n.queries.AddStatuses(ql.Query, statusCounts)
 			n.mu.Unlock()
 		}
 	}
@@ -328,8 +442,8 @@ func (t *traverser) handleQuery(ctx context.Context, ql queryLine) {
 func (n *node) overLimit(limit int) bool {
 	n.mu.Lock()
 	defer n.mu.Unlock()
-	if limit > 0 && len(n.Queries) > limit {
-		log.V(5).Info("Query limit reached", "class", n.Class, "queries", len(n.Queries))
+	if limit > 0 && len(n.queries) > limit {
+		log.V(5).Info("Query limit reached", "class", n.class, "queries", len(n.queries))
 		return true
 	}
 	return false
@@ -341,10 +455,10 @@ func (n *node) overLimit(limit int) bool {
 func (t *traverser) applyRules(ctx context.Context, n *node, nextDepth int) {
 	// Snapshot the objects, update processed, release the lock
 	n.mu.Lock()
-	objects := n.Result.List()
+	objects := n.result.List()
 	start := n.processed
 	n.processed = len(objects)
-	class := n.Class
+	class := n.class
 	n.mu.Unlock()
 
 	if start >= len(objects) {
@@ -361,8 +475,9 @@ func (t *traverser) applyRules(ctx context.Context, n *node, nextDepth int) {
 			log.V(4).Info("Rule applied", "name", r.Name(), "start", class, "error", err, "queries", len(queries))
 			metricRules.Add(ctx, 1, t.ruleAttrs[r])
 			for _, q := range queries {
-				if line := t.lines[lineKey{start: class, rule: r, goal: q.Class()}]; line != nil {
-					t.dedupAndSend(ctx, queryLine{Query: q, Line: line, depth: nextDepth})
+				key := lineKey{start: class, rule: r, goal: q.Class()}
+				if line := t.lines[key]; line != nil {
+					t.dedupAndSend(ctx, queryLine{Query: q, Line: line, key: key, depth: nextDepth})
 				}
 			}
 		}

--- a/pkg/engine/traverse/traverse_test.go
+++ b/pkg/engine/traverse/traverse_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/korrel8r/korrel8r/internal/pkg/test/mock"
 	"github.com/korrel8r/korrel8r/pkg/engine"
+	"github.com/korrel8r/korrel8r/pkg/graph"
 	"github.com/korrel8r/korrel8r/pkg/korrel8r"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -326,4 +327,151 @@ func TestTraverserNeighbors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func lineStrings(lines []*graph.Line) []string {
+	s := make([]string, len(lines))
+	for i, l := range lines {
+		s[i] = l.String()
+	}
+	return s
+}
+
+func TestGoalScope(t *testing.T) {
+	b := mock.NewBuilder("d")
+	r := b.Rule
+	// Paths:
+	// a-(b1,b2)-c len(3)
+	// a-(b1,b2)-c-d len(4)
+	// a-x-y-z-d len(5)
+	g := graph.NewData(
+		r("ab", "d:a", "d:b", nil),
+		r("bc1", "d:b", "d:c", nil),
+		r("bc2", "d:b", "d:c", nil),
+		r("cd", "d:c", "d:d", nil),
+		r("ax", "d:a", "d:x", nil),
+		r("xy", "d:x", "d:y", nil),
+		r("yz", "d:y", "d:z", nil),
+		r("za", "d:z", "d:a", nil), // Cycle
+		r("zd", "d:z", "d:d", nil),
+		r("ze", "d:z", "d:e", nil),
+		r("ed", "d:e", "d:d", nil),
+	).FullGraph()
+
+	for _, x := range []struct {
+		name  string
+		start korrel8r.Class
+		goals []korrel8r.Class
+		lines []string
+	}{
+		{
+			name:  "shortest",
+			start: b.Class("d:a"),
+			goals: b.Classes("d:c"),
+			lines: []string{"ab(d:a->d:b)", "bc1(d:b->d:c)", "bc2(d:b->d:c)"},
+		},
+		{
+			name:  "k-shortest+1",
+			start: b.Class("d:a"),
+			goals: b.Classes("d:d"),
+			lines: []string{
+				"ab(d:a->d:b)", "bc1(d:b->d:c)", "bc2(d:b->d:c)", "cd(d:c->d:d)",
+				"ax(d:a->d:x)", "xy(d:x->d:y)", "yz(d:y->d:z)", "zd(d:z->d:d)"},
+		},
+		{
+			name:  "cycle",
+			start: b.Class("d:a"),
+			goals: b.Classes("d:z"),
+			lines: []string{"ax(d:a->d:x)", "xy(d:x->d:y)", "yz(d:y->d:z)"},
+		},
+	} {
+		t.Run(x.name, func(t *testing.T) {
+			lines, err := goalScope(g, x.start, x.goals)
+			if assert.NoError(t, err) {
+				assert.ElementsMatch(t, x.lines, lineStrings(lines))
+			}
+		})
+	}
+
+	t.Run("error_bad_start", func(t *testing.T) {
+		_, err := goalScope(g, b.Class("d:missing"), b.Classes("d:b"))
+		assert.Error(t, err)
+	})
+
+	t.Run("error_bad_goal", func(t *testing.T) {
+		_, err := goalScope(g, b.Class("d:a"), b.Classes("d:missing"))
+		assert.Error(t, err)
+	})
+}
+
+func TestNeighborScope(t *testing.T) {
+	b := mock.NewBuilder("d")
+	r := b.Rule
+	g := graph.NewData(
+		r("ab", "d:a", "d:b", nil),
+		r("ac", "d:a", "d:c", nil),
+		r("bx", "d:b", "d:x", nil),
+		r("cy", "d:c", "d:y", nil),
+		r("yz", "d:y", "d:z", nil),
+		r("zq", "d:z", "d:q", nil),
+	).FullGraph()
+
+	for _, x := range []struct {
+		depth int
+		lines []string
+	}{
+		{
+			depth: 0,
+			lines: []string{},
+		},
+		{
+			depth: 1,
+			lines: []string{
+				"ab(d:a->d:b)",
+				"ac(d:a->d:c)",
+			},
+		},
+		{
+			depth: 2,
+			lines: []string{
+				"ab(d:a->d:b)",
+				"ac(d:a->d:c)",
+				"bx(d:b->d:x)",
+				"cy(d:c->d:y)",
+			},
+		},
+		{
+			depth: 3,
+			lines: []string{
+				"ab(d:a->d:b)",
+				"ac(d:a->d:c)",
+				"bx(d:b->d:x)",
+				"cy(d:c->d:y)",
+				"yz(d:y->d:z)",
+			},
+		},
+		{
+			depth: 4,
+			lines: []string{
+				"ab(d:a->d:b)",
+				"ac(d:a->d:c)",
+				"bx(d:b->d:x)",
+				"cy(d:c->d:y)",
+				"yz(d:y->d:z)",
+				"zq(d:z->d:q)",
+			},
+		},
+	} {
+		t.Run(fmt.Sprintf("depth %v", x.depth), func(t *testing.T) {
+			lines, err := neighborScope(g, b.Class("d:a"), x.depth)
+			if assert.NoError(t, err) {
+				assert.ElementsMatch(t, x.lines, lineStrings(lines))
+			}
+		})
+	}
+
+	t.Run("error_bad_start", func(t *testing.T) {
+		_, err := neighborScope(g, b.Class("d:missing"), 1)
+		assert.Error(t, err)
+	})
 }

--- a/pkg/graph/data.go
+++ b/pkg/graph/data.go
@@ -26,8 +26,8 @@ type Data struct {
 	Lines  []*Line          // Lines, index == Line.ID()
 	nodeID map[string]int64 // Map by full class name
 
-	topo     *Graph    // Lazy read-only topology graph with immutable nodes/lines.
-	topoOnce sync.Once // Guards topo construction.
+	shared     *Graph    // Lazy read-only graph with immutable nodes/lines.
+	sharedOnce sync.Once // Guards shared graph construction.
 }
 
 // NewData creates a new data set from a list of rules.
@@ -92,21 +92,21 @@ func (d *Data) FullGraph() *Graph {
 	return g
 }
 
-// TopoGraph returns a read-only topology graph backed by Data's immutable nodes and lines.
-// Built once and shared across all callers. Use for BFS/pathfinding, then build mutable
-// subgraphs via GoalPaths/Neighbors for traversal.
-func (d *Data) TopoGraph() *Graph {
-	d.topoOnce.Do(func() {
-		d.topo = New(d)
-		d.topo.allLines = d.Lines
+// SharedGraph returns a read-only graph backed by Data's nodes and lines.
+// It is built once and shared by all callers.
+// Use to build mutable sub-graphs for traversal.
+func (d *Data) SharedGraph() *Graph {
+	d.sharedOnce.Do(func() {
+		d.shared = New(d)
+		d.shared.allLines = d.Lines
 		for _, n := range d.Nodes {
-			d.topo.AddNode(n)
+			d.shared.AddNode(n)
 		}
 		for _, l := range d.Lines {
-			d.topo.SetLine(l)
+			d.shared.SetLine(l)
 		}
 	})
-	return d.topo
+	return d.shared
 }
 
 // Rules returns a copy of the complete list of rules.

--- a/pkg/graph/graph.go
+++ b/pkg/graph/graph.go
@@ -17,7 +17,6 @@ import (
 	"gonum.org/v1/gonum/graph/encoding"
 	"gonum.org/v1/gonum/graph/multi"
 	"gonum.org/v1/gonum/graph/path"
-	"gonum.org/v1/gonum/graph/traverse"
 )
 
 // Graph is a directed multigraph with [korrel8r.Class] nodes and [korrel8r.Rule] lines.
@@ -178,55 +177,6 @@ func (g *Graph) DOTAttributers() (graph, node, edge encoding.Attributer) {
 	return g.GraphAttrs, g.NodeAttrs, g.EdgeAttrs
 }
 
-// GoalPaths returns a new mutable sub-graph of nodes on a path to the goal class.
-// Includes k-shortest paths with cost <= shortest+1.
-func (g *Graph) GoalPaths(start korrel8r.Class, goals []korrel8r.Class) (*Graph, error) {
-	u, err := g.NodeForErr(start)
-	if err != nil {
-		return nil, err
-	}
-	sub := g.Data.EmptyGraph()
-	sub.copyNode(u)
-	for _, goal := range goals {
-		v, err := g.NodeForErr(goal)
-		if err != nil {
-			return nil, err
-		}
-		// Find shortest paths, and shortest+1 paths
-		paths := path.YenKShortestPaths(g, -1, 1, u, v)
-		for _, p := range paths {
-			for i := 1; i < len(p); i++ {
-				lines := g.Lines(p[i-1].ID(), p[i].ID())
-				for lines.Next() {
-					sub.copyLine(lines.Line().(*Line))
-				}
-			}
-		}
-	}
-	return sub, nil
-}
-
-// Neighbors returns a mutable breadth-first neighborhood following up to maxDepth edges from start.
-func (g *Graph) Neighbors(start korrel8r.Class, maxDepth int) (*Graph, error) {
-	sub := g.Data.EmptyGraph()
-	u, err := g.NodeForErr(start)
-	if err != nil {
-		return nil, err
-	}
-	sub.copyNode(u)
-	depth := 0
-	bf := traverse.BreadthFirst{
-		Traverse: func(e graph.Edge) bool {
-			ok := depth < maxDepth
-			if ok {
-				EdgeFor(e).EachLine(func(l *Line) { sub.copyLine(l) })
-			}
-			return ok
-		}}
-	_ = bf.Walk(g, u, func(n graph.Node, d int) bool { depth = d; return d > maxDepth })
-	return sub, nil
-}
-
 // FindLine finds a line between start and goal with rule. Nil if not found.
 func (g *Graph) FindLine(start, goal korrel8r.Class, rule korrel8r.Rule) *Line {
 	u, v := g.NodeFor(start), g.NodeFor(goal)
@@ -241,6 +191,12 @@ func (g *Graph) FindLine(start, goal korrel8r.Class, rule korrel8r.Rule) *Line {
 		}
 	}
 	return nil
+}
+
+// AddLine adds a line to the graph and the allLines cache.
+func (g *Graph) AddLine(l *Line) {
+	g.SetLine(l)
+	g.allLines = append(g.allLines, l)
 }
 
 // Remove empty nodes and lines from the graph.

--- a/pkg/graph/graph_test.go
+++ b/pkg/graph/graph_test.go
@@ -9,80 +9,9 @@ import (
 	"testing"
 
 	"github.com/korrel8r/korrel8r/internal/pkg/test/mock"
-	"github.com/korrel8r/korrel8r/pkg/korrel8r"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestGoalPaths(t *testing.T) {
-	b := mock.NewBuilder("d")
-	r := b.Rule
-	// Paths:
-	// a-(b1,b2)-c len(3)
-	// a-(b1,b2)-c-d len(4)
-	// a-x-y-z-d len(5)
-	g := NewData(
-		r("ab", "d:a", "d:b", nil),
-		r("bc1", "d:b", "d:c", nil),
-		r("bc2", "d:b", "d:c", nil),
-		r("cd", "d:c", "d:d", nil),
-		r("ax", "d:a", "d:x", nil),
-		r("xy", "d:x", "d:y", nil),
-		r("yz", "d:y", "d:z", nil),
-		r("za", "d:z", "d:a", nil), // Cycle
-		r("zd", "d:z", "d:d", nil),
-		r("ze", "d:z", "d:e", nil),
-		r("ed", "d:e", "d:d", nil),
-	).FullGraph()
-
-	for _, x := range []struct {
-		name         string
-		start        korrel8r.Class
-		goals        []korrel8r.Class
-		lines, nodes []string
-	}{
-		{
-			name:  "shortest",
-			start: b.Class("d:a"),
-			goals: b.Classes("d:c"),
-			lines: []string{"ab(d:a->d:b)", "bc1(d:b->d:c)", "bc2(d:b->d:c)"},
-			nodes: []string{"d:a", "d:b", "d:c"},
-		},
-		{
-			name:  "k-shortest+1",
-			start: b.Class("d:a"),
-			goals: b.Classes("d:d"),
-			lines: []string{
-				"ab(d:a->d:b)", "bc1(d:b->d:c)", "bc2(d:b->d:c)", "cd(d:c->d:d)",
-				"ax(d:a->d:x)", "xy(d:x->d:y)", "yz(d:y->d:z)", "zd(d:z->d:d)"},
-			nodes: []string{"d:a", "d:b", "d:c", "d:d", "d:x", "d:y", "d:z"},
-		},
-		{
-			name:  "weighted shortest",
-			start: b.Class("d:a"),
-			goals: b.Classes("d:d"),
-			lines: []string{
-				"ab(d:a->d:b)", "bc1(d:b->d:c)", "bc2(d:b->d:c)", "cd(d:c->d:d)",
-				"ax(d:a->d:x)", "xy(d:x->d:y)", "yz(d:y->d:z)", "zd(d:z->d:d)"},
-			nodes: []string{"d:a", "d:b", "d:c", "d:d", "d:x", "d:y", "d:z"},
-		},
-		{
-			name:  "cycle",
-			start: b.Class("d:a"),
-			goals: b.Classes("d:z"),
-			lines: []string{"ax(d:a->d:x)", "xy(d:x->d:y)", "yz(d:y->d:z)"},
-			nodes: []string{"d:a", "d:x", "d:y", "d:z"},
-		},
-	} {
-		t.Run(x.name, func(t *testing.T) {
-			sub, err := g.GoalPaths(x.start, x.goals)
-			if assert.NoError(t, err) {
-				assert.ElementsMatch(t, x.lines, sub.LineStrings(), "%#v", sub.LineStrings())
-				assert.ElementsMatch(t, x.nodes, sub.NodeStrings(true), "%#v", sub.NodeStrings(true))
-			}
-		})
-	}
-}
 
 func TestTwoPaths(t *testing.T) {
 	b := mock.NewBuilder("d")
@@ -97,137 +26,19 @@ func TestTwoPaths(t *testing.T) {
 		r("ax", "d:a", "d:x", b.Query("d:x", "ax", 4)),
 	).FullGraph()
 
-	t.Run("Neighbors", func(t *testing.T) {
-		sub, err := g.Neighbors(b.Class("d:a"), 2)
-		if assert.NoError(t, err) {
-			assert.ElementsMatch(t, []string{
-				"ab(d:a->d:b)",
-				"bc(d:b->d:c)",
-				"ac(d:a->d:c)",
-				"ax(d:a->d:x)",
-			}, sub.LineStrings())
-			assert.ElementsMatch(t, []string{
-				"d:a",
-				"d:b",
-				"d:c",
-				"d:x",
-			}, sub.NodeStrings(true))
-		}
-	})
-
-	t.Run("Goals", func(t *testing.T) {
-		sub, err := g.GoalPaths(b.Class("d:a"), b.Classes("d:c"))
-		if assert.NoError(t, err) {
-			assert.ElementsMatch(t, []string{
-				"ab(d:a->d:b)",
-				"bc(d:b->d:c)",
-				"ac(d:a->d:c)",
-			}, sub.LineStrings())
-			assert.ElementsMatch(t, []string{
-				"d:a",
-				"d:b",
-				"d:c",
-			}, sub.NodeStrings(true))
-		}
-	})
-}
-
-func TestNeighbors(t *testing.T) {
-	b := mock.NewBuilder("d")
-	r := b.Rule
-	g := NewData(
-		r("ab", "d:a", "d:b", nil),
-		r("ac", "d:a", "d:c", nil),
-		r("bx", "d:b", "d:x", nil),
-		r("cy", "d:c", "d:y", nil),
-		r("yz", "d:y", "d:z", nil),
-		r("zq", "d:z", "d:q", nil),
-	).FullGraph()
-
-	for _, x := range []struct {
-		depth int
-		lines []string
-		nodes []string
-	}{
-		{
-			depth: 4,
-			lines: []string{
-				"ab(d:a->d:b)",
-				"ac(d:a->d:c)",
-				"bx(d:b->d:x)",
-				"cy(d:c->d:y)",
-				"yz(d:y->d:z)",
-				"zq(d:z->d:q)",
-			},
-			nodes: []string{
-				"d:a",
-				"d:b",
-				"d:c",
-				"d:x",
-				"d:y",
-				"d:z",
-				"d:q",
-			},
-		},
-		{
-			depth: 3,
-			lines: []string{
-				"ab(d:a->d:b)",
-				"ac(d:a->d:c)",
-				"bx(d:b->d:x)",
-				"cy(d:c->d:y)",
-				"yz(d:y->d:z)",
-			},
-			nodes: []string{
-				"d:a",
-				"d:b",
-				"d:c",
-				"d:x",
-				"d:y",
-				"d:z",
-			},
-		},
-		{
-			depth: 2,
-			lines: []string{
-				"ab(d:a->d:b)",
-				"ac(d:a->d:c)",
-				"bx(d:b->d:x)",
-				"cy(d:c->d:y)",
-			},
-			nodes: []string{
-				"d:a",
-				"d:b",
-				"d:c",
-				"d:x",
-				"d:y",
-			},
-		},
-		{
-			depth: 1, lines: []string{
-				"ab(d:a->d:b)",
-				"ac(d:a->d:c)",
-			},
-			nodes: []string{
-				"d:a",
-				"d:b",
-				"d:c",
-			},
-		},
-		{
-			depth: 0,
-			lines: []string{},
-			nodes: []string{"d:a"},
-		},
-	} {
-		t.Run(fmt.Sprintf("depth %v", x.depth), func(t *testing.T) {
-			sub, err := g.Neighbors(b.Class("d:a"), x.depth)
-			if assert.NoError(t, err) {
-				assert.ElementsMatch(t, x.lines, sub.LineStrings())
-				assert.ElementsMatch(t, x.nodes, sub.NodeStrings(true))
-			}
-		})
-	}
+	sub := g.Select(func(l *Line) bool { return true })
+	assert.ElementsMatch(t, []string{
+		"ab(d:a->d:b)",
+		"bc(d:b->d:c)",
+		"ac(d:a->d:c)",
+		"ax(d:a->d:x)",
+	}, sub.LineStrings())
+	assert.ElementsMatch(t, []string{
+		"d:a",
+		"d:b",
+		"d:c",
+		"d:x",
+	}, sub.NodeStrings(true))
 }
 
 func TestWeight(t *testing.T) {
@@ -514,27 +325,4 @@ func TestRemoveEmptyGoalPaths(t *testing.T) {
 		g.EachNode(func(n *Node) { nodes = append(nodes, n.Class.String()) })
 		assert.Empty(t, nodes)
 	})
-}
-
-func TestGoalPaths_Errors(t *testing.T) {
-	b := mock.NewBuilder("d")
-	r := b.Rule
-	g := NewData(r("ab", "d:a", "d:b", nil)).FullGraph()
-
-	// Non-existent start
-	_, err := g.GoalPaths(b.Class("d:z"), b.Classes("d:b"))
-	assert.Error(t, err)
-
-	// Non-existent goal
-	_, err = g.GoalPaths(b.Class("d:a"), b.Classes("d:z"))
-	assert.Error(t, err)
-}
-
-func TestNeighbors_Error(t *testing.T) {
-	b := mock.NewBuilder("d")
-	r := b.Rule
-	g := NewData(r("ab", "d:a", "d:b", nil)).FullGraph()
-
-	_, err := g.Neighbors(b.Class("d:z"), 1)
-	assert.Error(t, err)
 }


### PR DESCRIPTION
benchmark comparison:
pkg: github.com/korrel8r/korrel8r/pkg/engine/traverse
             │   sec/op    │   sec/op     vs base                  │
Neighbors-16   4.018m ± 2%   2.738m ± 2%  -31.86% (p=0.000 n=10+6)
Goals-16       1.083m ± 4%   1.029m ± 1%   -4.94% (p=0.000 n=10+6)
geomean        2.086m        1.679m       -19.52%