### PR TITLE
chore: update devspace configuration

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,6 +4,7 @@ FROM registry.access.redhat.com/ubi10/go-toolset AS builder
 
 USER 0
 WORKDIR /src
+
 # Download and cache go modules before building.
 COPY go.mod go.sum ./
 COPY pkg/api/go.mod pkg/api/go.sum pkg/api/

--- a/devspace.Containerfile
+++ b/devspace.Containerfile
@@ -14,9 +14,10 @@ ENV GOCACHE=/src/go-build
 ENV GOBIN=/usr/bin
 RUN mkdir -p $GOCACHE $GOMODCACHE
 
-# Download and cache go modules.
-COPY go.mod go.mod
-COPY go.sum go.sum
+# Download and cache go modules before building.
+COPY go.mod go.sum ./
+COPY pkg/api/go.mod pkg/api/go.sum pkg/api/
+COPY pkg/mcp/go.mod pkg/mcp/go.sum pkg/mcp/
 RUN go mod download -x
 
 RUN mkdir -p /.devspace

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -1,24 +1,16 @@
 version: v2beta1
 name: korrel8r
 
-functions:
-  # Scale down COO so it doesn't fight over the korrel8r deployment
-  scale_down_coo: kubectl scale --replicas=0 -n ${DEVSPACE_NAMESPACE} deployment/observability-operator
-  scale_up_coo:   kubectl scale --replicas=1 -n ${DEVSPACE_NAMESPACE} deployment/observability-operator
-
 # This is a list of `pipelines` that DevSpace can execute (you can define your own)
 pipelines:
   # This is the pipeline for the main command: `devspace dev` (or `devspace run-pipeline dev`)
   dev:
-    run: |-
-      scale_down_coo
-      start_dev app                # Start dev mode "app" (see "dev" section)
+    run: start_dev app # Start dev mode "app" (see "dev" section)
 
   # Pipelilne to return to norml: `devspace purge`
   purge:
-    run: |-
-      stop_dev --all
-      scale_up_coo
+    run: stop_dev --all
+
 vars:
   REGISTRY_BASE:
 dev:
@@ -42,16 +34,16 @@ dev:
 
     # Sync local files necessary for auto-rebuild to the development container.
     sync:
-      - path: './:/src'
+      - path: "./:/src"
         excludePaths:
-          - '**'
-          - '!/Makefile'
-          - '!/go.mod'
-          - '!/go.sum'
-          - '!/cmd'
-          - '!/pkg'
-          - '!/internal'
-          - '!/etc'
+          - "**"
+          - "!/Makefile"
+          - "!/go.mod"
+          - "!/go.sum"
+          - "!/cmd"
+          - "!/pkg"
+          - "!/internal"
+          - "!/etc"
         onUpload:
           restartContainer: true
         startContainer: true


### PR DESCRIPTION
- add new modules to devspace.Containerfile
- remove COO scale down/up from devspace.yaml

Scaling down the COO no longer works, as it disables all COO-manged consoleplugins.
Remove these lines from devspace.yaml so devspace can be used without the COO.