### PR TITLE
doc: more concise MCP descriptions and instructions

### DIFF
--- a/doc/content/docs/reference/mcp/index.md
+++ b/doc/content/docs/reference/mcp/index.md
@@ -17,21 +17,7 @@ Korrel8r provides an [MCP](https://modelcontextprotocol.io/) server with the fol
 
 ## create_goals_graph
 
-Search for correlations between start objects and specific goal classes.
-Only follows paths from the start objects that lead to one of the specified goal classes.
-
-Returns a graph where nodes represent classes (each with queries and result counts)
-and edges represent correlation rules that were applied.
-
-Use this for targeted investigation: "find logs related to this pod" or "what alerts fired for this deployment?"
-
-The start parameter uses queries in "domain:class:selector" format.
-Use 'help' to learn the class and query syntax for each domain.
-Goals are full class names, e.g. ["log:application"], ["alert:alert", "metric:metric"].
-
-Example: to find logs for a crashing pod, use:
-  start: {"queries": ["k8s:Pod:{\"namespace\":\"myapp\",\"name\":\"web-0\"}"]}
-  goals: ["log:application"]
+Follow correlation paths from start objects to specific goal classes. Returns a graph of correlated classes with queries and result counts. Use for targeted queries like "find logs for this pod" or "what alerts fired for this deployment?" Start queries use "domain:class:selector" format; goals are class names like ["log:application"]. See 'help' for syntax.
 
 ### Input parameters
 
@@ -49,19 +35,7 @@ Example: to find logs for a crashing pod, use:
 
 ## create_neighbors_graph
 
-Search for correlated observability signals and resources starting from known objects.
-Follows correlation rules outward from the start objects up to the specified depth.
-
-Returns a graph where nodes represent classes (each with queries and result counts)
-and edges represent correlation rules that were applied.
-
-Use this for open-ended exploration: "what is related to this pod?" or "what resources are related to these traces?"
-
-The start parameter requires queries in the format "domain:class:selector".
-Use 'help' to learn the class and query syntax for each domain.
-Depth controls how many correlation steps to follow (1 = direct correlations only).
-Higher depths cast a wider net: depth 1 finds directly correlated objects,
-depth 2-3 typically reaches related signals like logs, metrics, and alerts.
+Follow correlation rules outward from start objects up to a given depth. Returns a graph of correlated classes with queries and result counts. Use for open-ended exploration like "what is related to this pod?" Depth 1 = direct correlations; depth 2-3 typically reaches logs, metrics, and alerts. Start queries use "domain:class:selector" format; see 'help' for syntax.
 
 ### Input parameters
 
@@ -79,15 +53,7 @@ depth 2-3 typically reaches related signals like logs, metrics, and alerts.
 
 ## get_console
 
-If the user refers to a console, use this tool to find out what the user is looking at.
-The result includes:
-- view: a korrel8r query selecting data displayed in the main console view.
-  Not set if the console is not displaying data.
-- search: parameters for the correlation search displayed in the troubleshooting panel.
-  Not set if the troubleshooting panel is not open.
-
-Use view and search to understand what the user is looking at,
-and include it as context for further planning or actions.
+Get what the user is looking at in the console. Returns a view query (main console view) and/or search parameters (troubleshooting panel), either may be absent. Use these as context for further actions.
 
 ### Output parameters
 
@@ -98,20 +64,7 @@ and include it as context for further planning or actions.
 
 ## get_objects
 
-Execute a query and return matching objects as complete JSON.
-The query must be in the format "domain:class:selector".
-Use 'help' to learn the query syntax for each domain.
-
-The returned objects are self-contained: all relevant labels and fields are included in each object.
-This differs from direct back-end APIs (e.g. Loki, Tempo) which use a compact "stream" format
-where common labels are sent once per stream. The complete format is more verbose
-but each object can be processed independently.
-
-Use the optional constraint parameter to control result size:
-- limit: maximum number of objects to return.
-- start/end: time range (RFC 3339) to restrict results by timestamp.
-Use constraints to avoid excessively large results, especially for
-high-volume domains like logs, metrics, and traces.
+Execute a query and return matching objects as self-contained JSON (all labels/fields included per object). Query format is "domain:class:selector"; see 'help' for syntax. Use the constraint parameter (limit number of objects, start/end time as RFC 3339) to control result size, especially for high-volume domains like logs, metrics, and traces.
 
 ### Input parameters
 
@@ -122,17 +75,7 @@ high-volume domains like logs, metrics, and traces.
 
 ## help
 
-Get help about korrel8r domains, classes, and query syntax.
-Omitting the domain parameter returns help about all domains.
-
-Class strings have the form "domain:class", where the legal values of "class" depend on the domain.
-
-Query strings have the form "domain:class:selector".
-The "domain:class" part indicates the class of data returned by the query.
-The "selector" part is a domain-specific query string.
-
-Use this tool to learn how to construct valid class names and queries for a domain before using tools that have class or query parameters.
-For example: create_neighbors_graph, create_goals_graph, get_console or show_in_console.
+Get help on domains, classes, and query syntax. Omit the domain parameter for help on all domains. Class names have the form "domain:class". Query strings have the form "domain:class:selector". Use this before constructing queries for other tools.
 
 ### Input parameters
 
@@ -148,12 +91,7 @@ For example: create_neighbors_graph, create_goals_graph, get_console or show_in_
 
 ## list_domain_classes
 
-List the classes in a domain.
-A class represents objects with a specific structure within a domain.
-Some domains have a single class (e.g. metric:metric), others like k8s have many classes.
-Use 'help' to get more details about a domain and its classes and queries.
-
-Class names are used in queries and as goal parameters. The full class name is "domain:class".
+List classes in a domain. A class represents objects with a specific structure. Full class names have the form "domain:class" and are used in queries and as goal parameters. Use 'help' for details on class and query syntax.
 
 ### Input parameters
 
@@ -170,9 +108,7 @@ Class names are used in queries and as goal parameters. The full class name is "
 
 ## list_domains
 
-Returns a list of Korrel8r domains with descriptions.
-A domain contains observable signals or resources that use the same query syntax and data store.
-Use this first to discover available domains, then use list_domain_classes to explore a domain.
+List available domains with descriptions. A domain groups signals or resources that share a query syntax and data store. Use 'list_domain_classes' or 'help' to explore a domain further.
 
 ### Output parameters
 
@@ -182,12 +118,7 @@ Use this first to discover available domains, then use list_domain_classes to ex
 
 ## show_in_console
 
-If the user refers to a console, use this tool to update the console to display new data.
-
-- view: setting this field to a query updates the main view of the console to display the results of the query.
-- search: setting this field displays a correlation graph in the console troubleshooting panel.
-
-Use 'help' to learn the class and query syntax for each domain.
+Update the console to display new data. Set 'view' to a query to update the main view, and/or set 'search' to display a correlation graph in the troubleshooting panel. See 'help' for query syntax.
 
 ### Input parameters
 

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -52,27 +52,15 @@ type ObjectsResult struct {
 	Objects []any `json:"objects" jsonschema:"List of objects matching the query"`
 }
 
-const Instructions = `
-Korrel8r finds correlations between observability signals and resources in a Kubernetes cluster.
+const Instructions = `Korrel8r finds correlations between observability signals and resources in a Kubernetes cluster.
 It connects data from different domains (logs, metrics, alerts, traces, Kubernetes resources, etc.)
 by following correlation rules to build a graph of related objects.
 
-## Console tools
+If the user refers to a console, use get_console and show_in_console to read and update it.
 
-If the user refers to a console:
-- Use get_console to find out what data the user is looking at, in the form of a korrel8r query.
-- Use show_in_console to display results in the console. Express the results as a korrel8r query.
-
-## Search tools
-
-1. Use list_domains to discover available domains.
-2. Use 'help' to get examples of classes and query syntax for a domain, or for all domains.
-3. Search for correlated data:
-   - Use create_goals_graph when the user asks about a specific signal type
-     (e.g. "find logs for this pod", "what alerts fired for this deployment?").
-   - Use create_neighbors_graph for open-ended exploration
-     (e.g. "what is related to this pod?", "show me everything connected to these traces").
-
+To search: use list_domains to discover domains, then 'help' to learn query syntax.
+Use create_goals_graph for targeted queries ("find logs for this pod")
+and create_neighbors_graph for open-ended exploration ("what is related to this pod?").
 `
 
 const (
@@ -130,12 +118,8 @@ func AddTools(server *mcp.Server, client *Client) []*mcp.Tool {
 	var tools []*mcp.Tool
 
 	addTool(&tools, server, &mcp.Tool{
-		Name: ListDomains,
-		Description: `
-Returns a list of Korrel8r domains with descriptions.
-A domain contains observable signals or resources that use the same query syntax and data store.
-Use this first to discover available domains, then use list_domain_classes to explore a domain.
-`,
+		Name:        ListDomains,
+		Description: `List available domains with descriptions. A domain groups signals or resources that share a query syntax and data store. Use 'list_domain_classes' or 'help' to explore a domain further.`,
 	},
 		func(ctx context.Context, req *mcp.CallToolRequest, input struct{}) (_ *mcp.CallToolResult, out ListDomainsResult, err error) {
 			domains, err := client.ListDomains(ctx)
@@ -146,15 +130,8 @@ Use this first to discover available domains, then use list_domain_classes to ex
 		})
 
 	addTool(&tools, server, &mcp.Tool{
-		Name: ListDomainClasses,
-		Description: `
-List the classes in a domain.
-A class represents objects with a specific structure within a domain.
-Some domains have a single class (e.g. metric:metric), others like k8s have many classes.
-Use 'help' to get more details about a domain and its classes and queries.
-
-Class names are used in queries and as goal parameters. The full class name is "domain:class".
-`,
+		Name:        ListDomainClasses,
+		Description: `List classes in a domain. A class represents objects with a specific structure. Full class names have the form "domain:class" and are used in queries and as goal parameters. Use 'help' for details on class and query syntax.`,
 	},
 		func(ctx context.Context, req *mcp.CallToolRequest, input DomainParams) (*mcp.CallToolResult, *ListDomainClassesResult, error) {
 			classes, err := client.ListDomainClasses(ctx, input.Domain)
@@ -165,20 +142,8 @@ Class names are used in queries and as goal parameters. The full class name is "
 		})
 
 	addTool(&tools, server, &mcp.Tool{
-		Name: Help,
-		Description: `
-Get help about korrel8r domains, classes, and query syntax.
-Omitting the domain parameter returns help about all domains.
-
-Class strings have the form "domain:class", where the legal values of "class" depend on the domain.
-
-Query strings have the form "domain:class:selector".
-The "domain:class" part indicates the class of data returned by the query.
-The "selector" part is a domain-specific query string.
-
-Use this tool to learn how to construct valid class names and queries for a domain before using tools that have class or query parameters.
-For example: create_neighbors_graph, create_goals_graph, get_console or show_in_console.
-`,
+		Name:        Help,
+		Description: `Get help on domains, classes, and query syntax. Omit the domain parameter for help on all domains. Class names have the form "domain:class". Query strings have the form "domain:class:selector". Use this before constructing queries for other tools.`,
 	},
 		func(ctx context.Context, req *mcp.CallToolRequest, input HelpParams) (*mcp.CallToolResult, *HelpResult, error) {
 			doc, err := client.Help(ctx, input.Domain)
@@ -189,22 +154,8 @@ For example: create_neighbors_graph, create_goals_graph, get_console or show_in_
 		})
 
 	addTool(&tools, server, &mcp.Tool{
-		Name: CreateNeighborsGraph,
-		Description: `
-Search for correlated observability signals and resources starting from known objects.
-Follows correlation rules outward from the start objects up to the specified depth.
-
-Returns a graph where nodes represent classes (each with queries and result counts)
-and edges represent correlation rules that were applied.
-
-Use this for open-ended exploration: "what is related to this pod?" or "what resources are related to these traces?"
-
-The start parameter requires queries in the format "domain:class:selector".
-Use 'help' to learn the class and query syntax for each domain.
-Depth controls how many correlation steps to follow (1 = direct correlations only).
-Higher depths cast a wider net: depth 1 finds directly correlated objects,
-depth 2-3 typically reaches related signals like logs, metrics, and alerts.
-`,
+		Name:        CreateNeighborsGraph,
+		Description: `Follow correlation rules outward from start objects up to a given depth. Returns a graph of correlated classes with queries and result counts. Use for open-ended exploration like "what is related to this pod?" Depth 1 = direct correlations; depth 2-3 typically reaches logs, metrics, and alerts. Start queries use "domain:class:selector" format; see 'help' for syntax.`,
 	},
 		func(ctx context.Context, req *mcp.CallToolRequest, input NeighborParams) (*mcp.CallToolResult, *api.Graph, error) {
 			g, err := client.GraphNeighbors(ctx, input)
@@ -215,24 +166,8 @@ depth 2-3 typically reaches related signals like logs, metrics, and alerts.
 		})
 
 	addTool(&tools, server, &mcp.Tool{
-		Name: CreateGoalsGraph,
-		Description: `
-Search for correlations between start objects and specific goal classes.
-Only follows paths from the start objects that lead to one of the specified goal classes.
-
-Returns a graph where nodes represent classes (each with queries and result counts)
-and edges represent correlation rules that were applied.
-
-Use this for targeted investigation: "find logs related to this pod" or "what alerts fired for this deployment?"
-
-The start parameter uses queries in "domain:class:selector" format.
-Use 'help' to learn the class and query syntax for each domain.
-Goals are full class names, e.g. ["log:application"], ["alert:alert", "metric:metric"].
-
-Example: to find logs for a crashing pod, use:
-  start: {"queries": ["k8s:Pod:{\"namespace\":\"myapp\",\"name\":\"web-0\"}"]}
-  goals: ["log:application"]
-`,
+		Name:        CreateGoalsGraph,
+		Description: `Follow correlation paths from start objects to specific goal classes. Returns a graph of correlated classes with queries and result counts. Use for targeted queries like "find logs for this pod" or "what alerts fired for this deployment?" Start queries use "domain:class:selector" format; goals are class names like ["log:application"]. See 'help' for syntax.`,
 	},
 		func(ctx context.Context, req *mcp.CallToolRequest, input GoalParams) (*mcp.CallToolResult, *api.Graph, error) {
 			g, err := client.GraphGoals(ctx, input)
@@ -243,23 +178,8 @@ Example: to find logs for a crashing pod, use:
 		})
 
 	addTool(&tools, server, &mcp.Tool{
-		Name: GetObjects,
-		Description: `
-Execute a query and return matching objects as complete JSON.
-The query must be in the format "domain:class:selector".
-Use 'help' to learn the query syntax for each domain.
-
-The returned objects are self-contained: all relevant labels and fields are included in each object.
-This differs from direct back-end APIs (e.g. Loki, Tempo) which use a compact "stream" format
-where common labels are sent once per stream. The complete format is more verbose
-but each object can be processed independently.
-
-Use the optional constraint parameter to control result size:
-- limit: maximum number of objects to return.
-- start/end: time range (RFC 3339) to restrict results by timestamp.
-Use constraints to avoid excessively large results, especially for
-high-volume domains like logs, metrics, and traces.
-`,
+		Name:        GetObjects,
+		Description: `Execute a query and return matching objects as self-contained JSON (all labels/fields included per object). Query format is "domain:class:selector"; see 'help' for syntax. Use the constraint parameter (limit number of objects, start/end time as RFC 3339) to control result size, especially for high-volume domains like logs, metrics, and traces.`,
 	},
 		func(ctx context.Context, req *mcp.CallToolRequest, input ObjectsParams) (*mcp.CallToolResult, *ObjectsResult, error) {
 			raw, err := client.GetObjects(ctx, input.Query, input.Constraint)
@@ -278,18 +198,8 @@ high-volume domains like logs, metrics, and traces.
 		})
 
 	addTool(&tools, server, &mcp.Tool{
-		Name: GetConsole,
-		Description: `
-If the user refers to a console, use this tool to find out what the user is looking at.
-The result includes:
-- view: a korrel8r query selecting data displayed in the main console view.
-  Not set if the console is not displaying data.
-- search: parameters for the correlation search displayed in the troubleshooting panel.
-  Not set if the troubleshooting panel is not open.
-
-Use view and search to understand what the user is looking at,
-and include it as context for further planning or actions.
-`,
+		Name:        GetConsole,
+		Description: `Get what the user is looking at in the console. Returns a view query (main console view) and/or search parameters (troubleshooting panel), either may be absent. Use these as context for further actions.`,
 	},
 		func(ctx context.Context, req *mcp.CallToolRequest, input struct{}) (*mcp.CallToolResult, *api.Console, error) {
 			console, err := client.GetConsole(ctx)
@@ -300,15 +210,8 @@ and include it as context for further planning or actions.
 		})
 
 	addTool(&tools, server, &mcp.Tool{
-		Name: ShowInConsole,
-		Description: `
-If the user refers to a console, use this tool to update the console to display new data.
-
-- view: setting this field to a query updates the main view of the console to display the results of the query.
-- search: setting this field displays a correlation graph in the console troubleshooting panel.
-
-Use 'help' to learn the class and query syntax for each domain.
-`,
+		Name:        ShowInConsole,
+		Description: `Update the console to display new data. Set 'view' to a query to update the main view, and/or set 'search' to display a correlation graph in the troubleshooting panel. See 'help' for query syntax.`,
 	},
 		func(ctx context.Context, req *mcp.CallToolRequest, update ShowInConsoleParams) (*mcp.CallToolResult, any, error) {
 			if err := client.ShowInConsole(ctx, &update); err != nil {


### PR DESCRIPTION
Shorter descriptions to improve human readability when accepting/rejecting tool use,
and to reduce token cost.