### PR TITLE
test: change cluster test marker from Cluster to _cluster

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ make help              # Show available targets and variables
 ### What Makes a Good PR
 
 - **Focused scope** - One logical change per PR. Separate refactoring from feature work.
-- **Tests included** - New features and bug fixes should include tests. Cluster tests should have "Cluster" in the test name.
+- **Tests included** - New features and bug fixes should include tests. Cluster test names must end with `_cluster` (e.g., `TestFoo_cluster`).
 - **Clear commit messages** - Describe what changed and why.
 
 ### Review Process

--- a/Containerfile
+++ b/Containerfile
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target="/root/.cache/go-build" CGO_ENABLED=1 GOOS=linux G
 RUN true
 
 # Build a minimal runtime image
-FROM registry.access.redhat.com/ubi10/ubi-minimal
+FROM registry.access.redhat.com/ubi10-micro
 
 WORKDIR /
 COPY --from=builder /src/korrel8r /usr/bin/korrel8r

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -107,7 +107,7 @@ devspace dev
 See [CONTRIBUTING.md](CONTRIBUTING.md) for test commands. Test organization:
 
 - **Package tests**: Standard Go tests in every `pkg/` sub-directory.
-- **Cluster tests**: "Cluster" in the test name (e.g., `TestClusterConnection`) means the test requires a cluster.
+- **Cluster tests**: Test names ending with `_cluster` (e.g., `TestTokenReview_cluster`) require a cluster.
 - **Rule tests**: Tests in `etc/korrel8r/rules/*_test.go` test rules defined in YAML configuration.
 
 ## Debugging

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ lint: ## Linting skipped (NOLINT is set).
 endif
 
 # Setting NO_CLUSTER=1 skips cluster tests
-TEST_FLAGS?=$(and $(NO_CLUSTER),-skip='Cluster|/Cluster')
+TEST_FLAGS?=$(and $(NO_CLUSTER),-skip='_cluster(-fm)?$$|/_cluster(-fm)?$$')
 
 .PHONY: test
 test: lint							 ## Run all tests, requires cluster. Set NO_CLUSTER=1 to skip cluster tests.

--- a/internal/pkg/test/domain/tests.go
+++ b/internal/pkg/test/domain/tests.go
@@ -17,7 +17,7 @@ import (
 func (f *Fixture) Test(t *testing.T) {
 	t.Helper()
 	f.Init(t)
-	for _, f := range []func(*testing.T){f.TestGet, f.TestMarshalUnmashal, f.TestGetCluster} {
+	for _, f := range []func(*testing.T){f.TestGet, f.TestMarshalUnmashal, f.TestGet_cluster} {
 		t.Run(funcName(f), f)
 	}
 }
@@ -53,9 +53,9 @@ func (f *Fixture) TestMarshalUnmashal(t *testing.T) {
 	require.Equal(t, o, o2)
 }
 
-// TestGetCluster that query constraints work with real stores.
+// TestGet_cluster that query constraints work with real stores.
 // Requires a cluster with the relevant signal stores available.
-func (f *Fixture) TestGetCluster(t *testing.T) {
+func (f *Fixture) TestGet_cluster(t *testing.T) {
 	t.Helper()
 	e := f.ClusterEngine(t)
 	limit := 3

--- a/pkg/domains/log/log_cluster_test.go
+++ b/pkg/domains/log/log_cluster_test.go
@@ -44,8 +44,8 @@ func routeHost(t *testing.T, c client.Client, namespace, name string) string {
 	return host
 }
 
-// TestPodQueriesCluster tests that pod-style queries work for direct and loki stores.
-func TestLogPodQueriesCluster(t *testing.T) {
+// TestLogPodQueries_cluster tests that pod-style queries work for direct and loki stores.
+func TestLogPodQueries_cluster(t *testing.T) {
 	// Set up pods to create logs.
 	c := test.RequireCluster(t)
 	const n = 10

--- a/pkg/rules/quickrules/k8s_test.go
+++ b/pkg/rules/quickrules/k8s_test.go
@@ -453,7 +453,7 @@ func TestK8sRules(t *testing.T) {
 	}
 }
 
-func TestInstanceToOperands_clusterScoped(t *testing.T) {
+func TestClusterInstanceToOperands(t *testing.T) {
 	const rule = "ClusterInstanceToOperands"
 	e := setup()
 	r := e.Rule(rule)

--- a/pkg/session/tokenreview_cluster_test.go
+++ b/pkg/session/tokenreview_cluster_test.go
@@ -12,7 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
-func TestTokenReviewCluster_SessionID(t *testing.T) {
+func TestTokenReview_SessionID_cluster(t *testing.T) {
 	cfg, err := config.GetConfig()
 	require.NoError(t, err)
 	require.NotEmpty(t, cfg.BearerToken, "cluster config must have a bearer token")

--- a/pkg/tokenreview/tokenreview_cluster_test.go
+++ b/pkg/tokenreview/tokenreview_cluster_test.go
@@ -10,7 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
-func TestTokenReviewCluster(t *testing.T) {
+func TestTokenReview_cluster(t *testing.T) {
 	cfg, err := config.GetConfig()
 	require.NoError(t, err)
 	require.NotEmpty(t, cfg.BearerToken, "cluster config must have a bearer token")
@@ -23,7 +23,7 @@ func TestTokenReviewCluster(t *testing.T) {
 	assert.NotEmpty(t, username, "should resolve bearer token to a username")
 }
 
-func TestTokenReviewCluster_InvalidToken(t *testing.T) {
+func TestTokenReview_InvalidToken_cluster(t *testing.T) {
 	_, err := config.GetConfig()
 	require.NoError(t, err)
 


### PR DESCRIPTION
Avoid problems with testing types or functions containing "Cluster"