### PR TITLE
fix: treat "invalid-query" as "not-found", not an error

### DIFF
--- a/pkg/domains/alert/alert.go
+++ b/pkg/domains/alert/alert.go
@@ -448,9 +448,10 @@ func (s *Store) getRulesWithNamespaceFilter(ctx context.Context, q *Query) (v1.R
 }
 
 func (s *Store) Get(ctx context.Context, query korrel8r.Query, c *korrel8r.Constraint, result korrel8r.Appender) error {
-	q, err := impl.TypeAssert[*Query](query)
-	if err != nil {
-		return err
+	// Type assertion errors are not store errors, treat as "not found".
+	q, ok := query.(*Query)
+	if !ok {
+		return nil
 	}
 
 	promAPI, err := newPrometheusClient(prometheus.EffectiveURL(ctx, s.prometheusURL, s.k8sClient), s.httpClient)

--- a/pkg/domains/incident/incident.go
+++ b/pkg/domains/incident/incident.go
@@ -135,9 +135,10 @@ func newPrometheusClient(u *url.URL, hc *http.Client) (v1.API, error) {
 }
 
 func (s Store) Get(ctx context.Context, query korrel8r.Query, c *korrel8r.Constraint, result korrel8r.Appender) error {
-	q, err := impl.TypeAssert[*Query](query)
-	if err != nil {
-		return err
+	// Type assertion errors are not store errors, treat as "not found".
+	q, ok := query.(*Query)
+	if !ok {
+		return nil
 	}
 
 	promq, t, err := preparePromQL(q, c)

--- a/pkg/domains/k8s/k8s.go
+++ b/pkg/domains/k8s/k8s.go
@@ -20,6 +20,7 @@ import (
 	"github.com/korrel8r/korrel8r/pkg/unique"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -292,17 +293,23 @@ func (s *Store) Client() client.WithWatch { return s.c }
 func (s *Store) Config() *rest.Config     { return s.cfg }
 
 func (s *Store) Get(ctx context.Context, query korrel8r.Query, c *korrel8r.Constraint, result korrel8r.Appender) (err error) {
-	// Skip the call if the class is not known
-	class, err := impl.TypeAssert[Class](query.Class())
-	if err != nil {
-		return err
+	// "not found" is not an error, return nil for not found errors
+	defer func() {
+		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			err = nil
+		}
+	}()
+	// Type assertion errors are not store errors, treat as "not found".
+	q, ok := query.(*Query)
+	if !ok {
+		return nil
+	}
+	class, ok := query.Class().(Class)
+	if !ok {
+		return nil
 	}
 	gvk := class.GVK()
 	if _, err := s.c.RESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version); err != nil {
-		return err
-	}
-	q, err := impl.TypeAssert[*Query](query)
-	if err != nil {
 		return err
 	}
 	appender := korrel8r.AppenderFunc(func(objs ...korrel8r.Object) {
@@ -317,9 +324,6 @@ func (s *Store) Get(ctx context.Context, query korrel8r.Query, c *korrel8r.Const
 		err = s.getObject(ctx, q, appender)
 	} else {
 		err = s.getList(ctx, q, appender, c)
-	}
-	if apierrors.IsNotFound(err) {
-		err = nil // Finding nothing is not an error.
 	}
 	return err
 }

--- a/pkg/domains/log/direct_store.go
+++ b/pkg/domains/log/direct_store.go
@@ -16,10 +16,10 @@ import (
 	"github.com/korrel8r/korrel8r/pkg/domains/k8s"
 	"github.com/korrel8r/korrel8r/pkg/korrel8r"
 	"github.com/korrel8r/korrel8r/pkg/korrel8r/impl"
-	"github.com/korrel8r/korrel8r/pkg/ptr"
 	"github.com/korrel8r/korrel8r/pkg/result"
 	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -39,9 +39,15 @@ func newDirectStore(k8sStore *k8s.Store) (*directStore, error) {
 }
 
 func (s *directStore) Get(ctx context.Context, query korrel8r.Query, constraint *korrel8r.Constraint, logResult korrel8r.Appender) (err error) {
-	q, err := impl.TypeAssert[*Query](query)
-	if err != nil {
-		return err
+	defer func() {
+		if errors.IsNotFound(err) {
+			err = nil // Finding nothing is not an error
+		}
+	}()
+	// Type assertion errors are not store errors, treat as "not found".
+	q, ok := query.(*Query)
+	if !ok {
+		return nil
 	}
 	if q.direct == nil {
 		return fmt.Errorf("direct log store cannot execute Loki query: %v", query)
@@ -77,7 +83,7 @@ func (s *directStore) Get(ctx context.Context, query korrel8r.Query, constraint 
 		}
 		var limit *int64
 		if constraint.GetLimit() > 0 {
-			limit = ptr.To(int64(constraint.GetLimit()))
+			limit = new(int64(constraint.GetLimit()))
 		}
 		for _, c := range pod.Spec.Containers {
 			if !q.direct.IsContainerSelected(c.Name) {
@@ -104,7 +110,10 @@ func (s *directStore) Get(ctx context.Context, query korrel8r.Query, constraint 
 					AttrKubernetesNamespaceName: pod.GetNamespace(),
 					AttrKubernetesContainerName: c.Name,
 				}
-				return s.readPodLogs(ctx, stream, out, attrs, constraint, count)
+				// Treat a failure as a "not found" condition, not an error.
+				// Don't fail the entire k8s store for a local pod problem.
+				_ = s.readPodLogs(ctx, stream, out, attrs, constraint, count)
+				return nil
 			})
 		}
 	}
@@ -129,12 +138,6 @@ func (s *directStore) readPodLogs(ctx context.Context, stream io.ReadCloser, out
 	// Scan the log lines, create log.Object
 	scanner := bufio.NewScanner(stream)
 	for scanner.Scan() {
-		if scanner.Err() != nil {
-			if scanner.Err() == io.EOF {
-				return ctx.Err()
-			}
-			return err
-		}
 		line := scanner.Text()
 		o := maps.Clone(attrs)
 		o[AttrBody] = line
@@ -160,7 +163,7 @@ func (s *directStore) readPodLogs(ctx context.Context, stream io.ReadCloser, out
 		}
 		out <- o
 	}
-	return nil
+	return scanner.Err()
 }
 
 type ContainerSelector struct {

--- a/pkg/domains/log/loki_store.go
+++ b/pkg/domains/log/loki_store.go
@@ -26,9 +26,10 @@ func NewLokiStore(base *url.URL, h *http.Client) korrel8r.Store {
 }
 
 func (s *lokiStore) Get(ctx context.Context, query korrel8r.Query, constraint *korrel8r.Constraint, r korrel8r.Appender) error {
-	q, err := impl.TypeAssert[*Query](query)
-	if err != nil {
-		return err
+	// Type assertion errors are not store errors, treat as "not found".
+	q, ok := query.(*Query)
+	if !ok {
+		return nil
 	}
 	return s.Client.Get(ctx, parseJSON(q.logQL), constraint, func(l *loki.Log) { r.Append(newObject(l)) })
 }
@@ -41,9 +42,10 @@ func NewLokiStackStore(base *url.URL, h *http.Client) korrel8r.Store {
 }
 
 func (s *lokiStackStore) Get(ctx context.Context, query korrel8r.Query, constraint *korrel8r.Constraint, r korrel8r.Appender) error {
-	q, err := impl.TypeAssert[*Query](query)
-	if err != nil {
-		return err
+	// Type assertion errors are not store errors, treat as "not found".
+	q, ok := query.(*Query)
+	if !ok {
+		return nil
 	}
 	return s.GetStack(ctx, parseJSON(q.logQL), string(q.class), constraint, func(l *loki.Log) { r.Append(newObject(l)) })
 }

--- a/pkg/domains/metric/metric.go
+++ b/pkg/domains/metric/metric.go
@@ -146,9 +146,10 @@ type response struct {
 }
 
 func (s *Store) Get(ctx context.Context, kquery korrel8r.Query, c *korrel8r.Constraint, result korrel8r.Appender) error {
-	query, err := impl.TypeAssert[Query](kquery)
-	if err != nil {
-		return err
+	// Type assertion errors are not store errors, treat as "not found".
+	query, ok := kquery.(Query)
+	if !ok {
+		return nil
 	}
 
 	baseURL := prometheus.EffectiveURL(ctx, s.baseURL, s.k8sClient).JoinPath("/api/v1")

--- a/pkg/domains/netflow/netflow.go
+++ b/pkg/domains/netflow/netflow.go
@@ -168,9 +168,10 @@ type store struct {
 
 func (store) Domain() korrel8r.Domain { return Domain }
 func (s *store) Get(ctx context.Context, query korrel8r.Query, c *korrel8r.Constraint, result korrel8r.Appender) error {
-	q, err := impl.TypeAssert[Query](query)
-	if err != nil {
-		return err
+	// Type assertion errors are not store errors, treat as "not found".
+	q, ok := query.(Query)
+	if !ok {
+		return nil
 	}
 	return s.Client.Get(ctx, q.Data(), c, func(e *loki.Log) { result.Append(NewObject(e)) })
 }
@@ -179,9 +180,10 @@ type stackStore struct{ store }
 
 func (stackStore) Domain() korrel8r.Domain { return Domain }
 func (s *stackStore) Get(ctx context.Context, query korrel8r.Query, c *korrel8r.Constraint, result korrel8r.Appender) error {
-	q, err := impl.TypeAssert[Query](query)
-	if err != nil {
-		return err
+	// Type assertion errors are not store errors, treat as "not found".
+	q, ok := query.(Query)
+	if !ok {
+		return nil
 	}
 
 	return s.GetStack(ctx, q.Data(), "network", c, func(e *loki.Log) { result.Append(NewObject(e)) })

--- a/pkg/domains/trace/trace.go
+++ b/pkg/domains/trace/trace.go
@@ -157,9 +157,10 @@ type stackStore struct{ store }
 
 func (stackStore) Domain() korrel8r.Domain { return Domain }
 func (s *stackStore) Get(ctx context.Context, query korrel8r.Query, c *korrel8r.Constraint, result korrel8r.Appender) error {
-	q, err := impl.TypeAssert[Query](query)
-	if err != nil {
-		return err
+	// Type assertion errors are not store errors, treat as "not found".
+	q, ok := query.(Query)
+	if !ok {
+		return nil
 	}
 
 	return s.GetStack(ctx, q.Data(), c, func(s *Span) { result.Append(s) })

--- a/pkg/engine/stores.go
+++ b/pkg/engine/stores.go
@@ -84,15 +84,15 @@ func (s *storeHolder) Get(ctx context.Context, q korrel8r.Query, constraint *kor
 		defer s.lock.Lock()
 		err = store.Get(ctx, q, constraint, result)
 	}()
-	if err != nil {
+	// Only reset if s.Store is still the same instance that failed.
+	// Another goroutine may have already replaced it while the lock was released.
+	if err != nil && s.Store == store && s.Original != nil {
 		s.recordErrorLH(err)
-		if s.Store != nil && s.Original != nil {
-			if c, _ := s.Store.(io.Closer); c != nil {
-				_ = c.Close()
-			}
-			s.Store = nil
-			s.retryAfter = time.Now().Add(s.Engine.Tuning.GetStoreRetryInterval())
+		if c, _ := s.Store.(io.Closer); c != nil {
+			_ = c.Close()
 		}
+		s.Store = nil
+		s.retryAfter = time.Now().Add(s.Engine.Tuning.GetStoreRetryInterval())
 	}
 
 	return err


### PR DESCRIPTION
Invalid query is not a store error and should not fail the store.
Treat it as a "not found" condition: empty result, no error.