### PR TITLE
fix(#431): don't revisit start node in neighbor graphs

### DIFF
--- a/pkg/engine/traverse/traverse.go
+++ b/pkg/engine/traverse/traverse.go
@@ -61,7 +61,9 @@ func Neighbors(ctx context.Context, e *engine.Engine, start Start, depth int) (*
 	if err != nil {
 		return nil, err
 	}
-	return newTraverser(e, shared.Data, scope, start.Constraint, depth).run(ctx, start)
+	t := newTraverser(e, shared.Data, scope, start.Constraint, depth)
+	t.skipStartClass = start.Class
+	return t.run(ctx, start)
 }
 
 // neighborScope returns the lines reachable within maxDepth BFS hops from start.
@@ -190,6 +192,7 @@ type traverser struct {
 	data       *graph.Data
 	constraint *korrel8r.Constraint
 	maxDepth   int // -1 for unlimited
+	skipStartClass korrel8r.Class
 
 	// Read-only after init
 	nodes      map[korrel8r.Class]*node
@@ -481,6 +484,10 @@ func (t *traverser) applyRules(ctx context.Context, n *node, nextDepth int) {
 			log.V(4).Info("Rule applied", "name", r.Name(), "start", class, "error", err, "queries", len(queries))
 			metricRules.Add(ctx, 1, t.ruleMetric[r])
 			for _, q := range queries {
+				if t.skipStartClass != nil && q.Class() == t.skipStartClass {
+					log.V(5).Info("Skipping query to start class", "rule", r.Name(), "query", q)
+					continue
+				}
 				key := lineKey{start: class, rule: r, goal: q.Class()}
 				if line := t.lines[key]; line != nil {
 					t.dedupAndSend(ctx, queryLine{Query: q, Line: line, key: key, depth: nextDepth})

--- a/pkg/engine/traverse/traverse_test.go
+++ b/pkg/engine/traverse/traverse_test.go
@@ -134,8 +134,8 @@ func TestTraverserCycle(t *testing.T) {
 		start := Start{Class: b.Class("d:a"), Objects: []korrel8r.Object{0}}
 		g, err := Neighbors(context.Background(), e, start, 2)
 		require.NoError(t, err)
-		assert.ElementsMatch(t, []string{"ab(d:a->d:b)", "ba(d:b->d:a)"}, g.LineStrings())
-		assert.ElementsMatch(t, []string{"d:a[0,2]", "d:b[1]"}, g.NodeStrings(true))
+		assert.ElementsMatch(t, []string{"ab(d:a->d:b)"}, g.LineStrings())
+		assert.ElementsMatch(t, []string{"d:a[0]", "d:b[1]"}, g.NodeStrings(true))
 	})
 
 	t.Run("three_node_cycle", func(t *testing.T) {
@@ -151,8 +151,8 @@ func TestTraverserCycle(t *testing.T) {
 		start := Start{Class: b.Class("d:a"), Objects: []korrel8r.Object{0}}
 		g, err := Neighbors(context.Background(), e, start, 3)
 		require.NoError(t, err)
-		assert.ElementsMatch(t, []string{"ab(d:a->d:b)", "bc(d:b->d:c)", "ca(d:c->d:a)"}, g.LineStrings())
-		assert.ElementsMatch(t, []string{"d:a[0,3]", "d:b[1]", "d:c[2]"}, g.NodeStrings(true))
+		assert.ElementsMatch(t, []string{"ab(d:a->d:b)", "bc(d:b->d:c)"}, g.LineStrings())
+		assert.ElementsMatch(t, []string{"d:a[0]", "d:b[1]", "d:c[2]"}, g.NodeStrings(true))
 	})
 
 	t.Run("cycle_with_branch", func(t *testing.T) {
@@ -172,11 +172,10 @@ func TestTraverserCycle(t *testing.T) {
 		assert.ElementsMatch(t, []string{
 			"ab(d:a->d:b)",
 			"bc(d:b->d:c)",
-			"ca(d:c->d:a)",
 			"ad(d:a->d:d)",
 		}, g.LineStrings())
 		assert.ElementsMatch(t, []string{
-			"d:a[0,3]", "d:b[1]", "d:c[2]", "d:d[4]",
+			"d:a[0]", "d:b[1]", "d:c[2]", "d:d[4]",
 		}, g.NodeStrings(true))
 	})
 }
@@ -210,8 +209,10 @@ func TestTraverserCycleUniqueQueries(t *testing.T) {
 		defer cancel()
 		start := Start{Class: b.Class("d:a"), Objects: []korrel8r.Object{"start"}}
 		g, err := Neighbors(ctx, e, start, 5)
-		require.NoError(t, err, "should terminate at depth limit without context cancellation")
-		assert.NotEmpty(t, g.NodeStrings(true), "should have results")
+		require.NoError(t, err, "should terminate without context cancellation")
+		// ba rule is skipped because it returns to the start node.
+		assert.Len(t, g.LineStrings(), 1, "only ab line, ba is skipped")
+		assert.Len(t, g.NodeStrings(true), 2, "only start and one neighbor")
 		t.Logf("nodes: %v", g.NodeStrings(true))
 		t.Logf("lines: %v", g.LineStrings())
 	})
@@ -226,6 +227,57 @@ func TestTraverserCycleUniqueQueries(t *testing.T) {
 		assert.NotEmpty(t, g.NodeStrings(true), "should have results")
 		t.Logf("nodes: %v", g.NodeStrings(true))
 		t.Logf("lines: %v", g.LineStrings())
+	})
+}
+
+func TestTraverserNoStartCycle(t *testing.T) {
+	t.Run("Neighbors_skips_back_to_start", func(t *testing.T) {
+		b := mock.NewBuilder("d")
+		r := b.Rule
+		e, err := engine.Build().Rules(
+			r("ab", "d:a", "d:b", b.Query("d:b", "ab", 1)),
+			r("bc", "d:b", "d:c", b.Query("d:c", "bc", 2)),
+			r("ca", "d:c", "d:a", b.Query("d:a", "ca", 3)),
+			r("cd", "d:c", "d:d", b.Query("d:d", "cd", 4)),
+		).Stores(b.Store("d", nil)).Engine()
+		require.NoError(t, err)
+
+		start := Start{Class: b.Class("d:a"), Objects: []korrel8r.Object{0}}
+		g, err := Neighbors(context.Background(), e, start, 4)
+		require.NoError(t, err)
+		// ca rule is skipped: it returns to the start class.
+		// cd rule fires: it goes to a new class.
+		assert.ElementsMatch(t, []string{
+			"ab(d:a->d:b)",
+			"bc(d:b->d:c)",
+			"cd(d:c->d:d)",
+		}, g.LineStrings())
+		assert.ElementsMatch(t, []string{
+			"d:a[0]", "d:b[1]", "d:c[2]", "d:d[4]",
+		}, g.NodeStrings(true))
+	})
+
+	t.Run("Goals_skips_back_to_start", func(t *testing.T) {
+		b := mock.NewBuilder("d")
+		r := b.Rule
+		e, err := engine.Build().Rules(
+			r("ab", "d:a", "d:b", b.Query("d:b", "ab", 1)),
+			r("ba", "d:b", "d:a", b.Query("d:a", "ba", 2)),
+			r("bc", "d:b", "d:c", b.Query("d:c", "bc", 3)),
+		).Stores(b.Store("d", nil)).Engine()
+		require.NoError(t, err)
+
+		start := Start{Class: b.Class("d:a"), Objects: []korrel8r.Object{0}}
+		g, err := Goals(context.Background(), e, start, []korrel8r.Class{b.Class("d:c")})
+		require.NoError(t, err)
+		// ba rule is skipped: it returns to the start class.
+		assert.ElementsMatch(t, []string{
+			"ab(d:a->d:b)",
+			"bc(d:b->d:c)",
+		}, g.LineStrings())
+		assert.ElementsMatch(t, []string{
+			"d:a[0]", "d:b[1]", "d:c[3]",
+		}, g.NodeStrings(true))
 	})
 }
 


### PR DESCRIPTION
Neighborhood search can return to start class via rule cycles, and then continue to 
search out from new "peer" objects of the start class.
This is confusing as the new relationships are not direct from the original start objects,

This fix prevents returning to the start node but allows following other cycles.