### PR TITLE
fix: outward only neighbor search algorithm

### DIFF
--- a/pkg/engine/traverse/traverse.go
+++ b/pkg/engine/traverse/traverse.go
@@ -16,9 +16,9 @@ package traverse
 
 import (
 	"context"
-
 	"math"
 	"runtime"
+	"slices"
 	"sync"
 
 	"github.com/korrel8r/korrel8r/internal/pkg/logging"
@@ -61,9 +61,7 @@ func Neighbors(ctx context.Context, e *engine.Engine, start Start, depth int) (*
 	if err != nil {
 		return nil, err
 	}
-	t := newTraverser(e, shared.Data, scope, start.Constraint, depth)
-	t.skipStartClass = start.Class
-	return t.run(ctx, start)
+	return newTraverser(e, shared.Data, scope, start.Constraint, depth).run(ctx, start)
 }
 
 // neighborScope returns the lines reachable within maxDepth BFS hops from start.
@@ -72,6 +70,7 @@ func neighborScope(shared *graph.Graph, start korrel8r.Class, maxDepth int) ([]*
 	if err != nil {
 		return nil, err
 	}
+	nodeDepth := map[int64]int{}
 	var lines []*graph.Line
 	depth := 0
 	bf := gonumTraverse.BreadthFirst{
@@ -83,7 +82,14 @@ func neighborScope(shared *graph.Graph, start korrel8r.Class, maxDepth int) ([]*
 			return ok
 		},
 	}
-	_ = bf.Walk(shared, u, func(n gonumGraph.Node, d int) bool { depth = d; return d > maxDepth })
+	_ = bf.Walk(shared, u, func(n gonumGraph.Node, d int) bool {
+		depth = d
+		nodeDepth[n.ID()] = d
+		return d > maxDepth
+	})
+	lines = slices.DeleteFunc(lines, func(l *graph.Line) bool {
+		return nodeDepth[l.From().ID()] > nodeDepth[l.To().ID()]
+	})
 	return lines, nil
 }
 
@@ -192,7 +198,6 @@ type traverser struct {
 	data       *graph.Data
 	constraint *korrel8r.Constraint
 	maxDepth   int // -1 for unlimited
-	skipStartClass korrel8r.Class
 
 	// Read-only after init
 	nodes      map[korrel8r.Class]*node
@@ -484,10 +489,6 @@ func (t *traverser) applyRules(ctx context.Context, n *node, nextDepth int) {
 			log.V(4).Info("Rule applied", "name", r.Name(), "start", class, "error", err, "queries", len(queries))
 			metricRules.Add(ctx, 1, t.ruleMetric[r])
 			for _, q := range queries {
-				if t.skipStartClass != nil && q.Class() == t.skipStartClass {
-					log.V(5).Info("Skipping query to start class", "rule", r.Name(), "query", q)
-					continue
-				}
 				key := lineKey{start: class, rule: r, goal: q.Class()}
 				if line := t.lines[key]; line != nil {
 					t.dedupAndSend(ctx, queryLine{Query: q, Line: line, key: key, depth: nextDepth})


### PR DESCRIPTION
Neighbor search only follows lines where start depth <= goal depth.
Reflexive lines are followed (start depth == goal depth)
Indirect cycles between different depths are not allowed.