### PR TITLE
chore: optimize devspace Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -18,9 +18,6 @@ COPY internal internal
 
 RUN --mount=type=cache,target="/root/.cache/go-build" CGO_ENABLED=1 GOOS=linux GOFLAGS="-mod=readonly -tags=strictfipsruntime,openssl" GOEXPERIMENT=strictfipsruntime go build -tags netgo ./cmd/korrel8r
 
-# Commit build cache
-RUN true
-
 # Build a minimal runtime image
 FROM registry.access.redhat.com/ubi10-micro
 

--- a/Makefile
+++ b/Makefile
@@ -172,10 +172,13 @@ release:
 	$(MAKE) image-latest
 	@echo Released $(VERSION) to $(REGISTRY_BASE)
 
-DEVSPACE_IMAGE?="$(REGISTRY_BASE)/korrel8r:devspace"
+DEVSPACE_TAG?=devspace-$(shell git rev-parse --short HEAD)-$(shell sha256sum go.sum | cut -c1-8)
+DEVSPACE_IMAGE?=$(REGISTRY_BASE)/korrel8r:$(DEVSPACE_TAG)
 devspace-image:	kustomize-edit ## Rebuild the devspace base image
-	$(IMGTOOL) build --tag=$(DEVSPACE_IMAGE) -f devspace.Containerfile
+	$(IMGTOOL) build --tag=$(DEVSPACE_IMAGE) -f devspace.Containerfile .
 	$(IMGTOOL) push $(DEVSPACE_IMAGE)
+	@mkdir -p .devspace
+	@echo $(DEVSPACE_IMAGE) > .devspace/devimage
 
 ## Documentation rules
 

--- a/devspace.Containerfile
+++ b/devspace.Containerfile
@@ -1,26 +1,29 @@
 # Go-tools container for devspace to sync and auto-build korrel8r.
 # Note: the Go version in this image must be compatible with ./go.mod
-FROM registry.access.redhat.com/ubi10/go-toolset AS builder
+FROM registry.access.redhat.com/ubi10/go-toolset
 
 USER 0
 WORKDIR /src
+
+# Pin cache paths so they match at build-time and runtime regardless of UID.
+# OpenShift runs containers as random non-root UIDs; without explicit paths the
+# runtime user gets different defaults and re-downloads everything.
+ENV GOMODCACHE=/go/pkg/mod \
+    GOCACHE=/go/cache/go-build \
+    GONOSUMDB=* \
+    GONOSUMCHECK=*
 
 # Download and cache go modules before building.
 COPY go.mod go.sum ./
 COPY pkg/api/go.mod pkg/api/go.sum pkg/api/
 COPY pkg/mcp/go.mod pkg/mcp/go.sum pkg/mcp/
-RUN go mod download -x
+RUN go mod download
 
-# Copy go sources and build
+# Copy go sources and pre-build to warm the build cache.
 COPY cmd cmd
 COPY pkg pkg
 COPY internal internal
+RUN go build ./...
 
-RUN --mount=type=cache,target="/root/.cache/go-build" CGO_ENABLED=1 GOOS=linux GOFLAGS="-mod=readonly -tags=strictfipsruntime,openssl" GOEXPERIMENT=strictfipsruntime go build -tags netgo ./cmd/korrel8r
-
-# Commit build cache
-RUN true
-
-# Create devspace workdir
-RUN mkdir -p /.devspace
-RUN chmod -R ug+rw /.devspace /src
+# Ensure caches and work dirs are writable by any UID (OpenShift random UIDs).
+RUN mkdir -p /.devspace && chmod -R a+rwX $GOMODCACHE $GOCACHE /src /.devspace

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -13,6 +13,8 @@ pipelines:
 
 vars:
   REGISTRY_BASE:
+  DEVSPACE_IMAGE:
+    command: bash -c "cat .devspace/devimage 2>/dev/null || echo $REGISTRY_BASE/korrel8r:devspace"
 dev:
   # app container replaces the COO's korrel8r deployment with an auto-rebuild container.
   # Changes to the local source are synced and cause a rebuild and restart of the container.
@@ -20,7 +22,7 @@ dev:
     # Find the korrel8r container by label selector.
     labelSelector: { app.kubernetes.io/instance: korrel8r }
     container: korrel8r
-    devImage: ${REGISTRY_BASE}/korrel8r:devspace
+    devImage: ${DEVSPACE_IMAGE}
     command:
       - go
       - run


### PR DESCRIPTION
Use a commit-based image version to load of the right go dependencies.