### PR TITLE
fix(185): add direct tempo lookup via /api/traces/<trace-id>

### DIFF
--- a/doc/content/docs/reference/domains/trace.md
+++ b/doc/content/docs/reference/domains/trace.md
@@ -22,7 +22,7 @@ Represents a [span](<https://opentelemetry.io/docs/concepts/signals/traces/#span
 Selector has two forms:
 
 - [TraceQL](<https://grafana.com/docs/tempo/latest/traceql/>) query string
-- A list of trace IDs.
+- A hexadecimal trace\-ID.
 
 A [TraceQL](<https://grafana.com/docs/tempo/latest/traceql/>) query can select spans from many traces. Example:
 
@@ -30,10 +30,10 @@ A [TraceQL](<https://grafana.com/docs/tempo/latest/traceql/>) query can select s
 trace:span:{resource.k8s.namespace.name="korrel8r"}
 ```
 
-A trace\-id query is a list of hexadecimal trace IDs. It returns all the spans included by each trace. Example:
+A trace\-id query returns all the spans included in a trace. Example:
 
 ```
-trace:span:a7880cc221e84e0d07b15993358811b7,b7880cc221e84e0d07b15993358811b7
+trace:span:a7880cc221e84e0d07b15993358811b7
 ```
 
 ### Store

--- a/etc/korrel8r/openshift-route.yaml
+++ b/etc/korrel8r/openshift-route.yaml
@@ -20,7 +20,7 @@ stores:
     lokiStack: 'https://{{k8sRouteHost "netobserv" "loki"}}'
 
   - domain: trace
-    tempoStack: 'https://{{k8sRouteHost "openshift-tracing" "tempo-platform-gateway"}}/api/traces/v1/platform/tempo/api/search'
+    tempoStack: 'https://{{k8sRouteHost "openshift-tracing" "tempo-platform-gateway"}}/api/traces/v1/platform/tempo'
 
   - domain: incident
     metrics: 'https://{{k8sRouteHost "openshift-monitoring" "thanos-querier"}}'

--- a/etc/korrel8r/openshift-svc.yaml
+++ b/etc/korrel8r/openshift-svc.yaml
@@ -23,7 +23,7 @@ stores:
     certificateAuthority: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
 
   - domain: trace
-    tempoStack: https://tempo-platform-gateway.openshift-tracing.svc.cluster.local:8080/api/traces/v1/platform/tempo/api/search
+    tempoStack: https://tempo-platform-gateway.openshift-tracing.svc.cluster.local:8080/api/traces/v1/platform/tempo
     certificateAuthority: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
 
   - domain: incident

--- a/pkg/domains/alert/alert.go
+++ b/pkg/domains/alert/alert.go
@@ -509,15 +509,24 @@ func (s *Store) Get(ctx context.Context, query korrel8r.Query, c *korrel8r.Const
 		log.V(5).Info("failed to get Alertmanager API", "error", amErr)
 	}
 
+	limit := c.GetLimit()
+	count := 0
 	for _, subquery := range q.Parsed {
+		if limit > 0 && count >= limit {
+			break
+		}
 		alerts, err := s.getSubquery(ctx, allRules, subquery, alertmanagerAPI)
 		if err != nil {
 			return err
 		}
 
 		for _, a := range alerts {
+			if limit > 0 && count >= limit {
+				break
+			}
 			if c.CompareTime(a.StartsAt) <= 0 && c.CompareTime(a.EndsAt) >= 0 {
 				result.Append(a)
+				count++
 			}
 		}
 	}

--- a/pkg/domains/alert/alert_domain_test.go
+++ b/pkg/domains/alert/alert_domain_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/korrel8r/korrel8r/pkg/domains/alert"
 )
 
-// TODO https://github.com/korrel8r/korrel8r/issues/148  store does not respect limits.
-// Remove ClusterSetup when fixed.
 var fixture = domain.Fixture{
 	Query:        &alert.Query{Qs: "{}"},
 	ClusterSetup: func(testing.TB) bool { return false },

--- a/pkg/domains/trace/doc.go
+++ b/pkg/domains/trace/doc.go
@@ -17,18 +17,17 @@
 //
 // Selector has two forms:
 //   - [TraceQL] query string
-//   - A list of trace IDs.
+//   - A hexadecimal trace-ID.
 //
 // A [TraceQL] query can select spans from many traces.
 // Example:
 //
 //	trace:span:{resource.k8s.namespace.name="korrel8r"}
 //
-// A trace-id query is a list of hexadecimal trace IDs.
-// It returns all the spans included by each trace.
+// A trace-id query returns all the spans included in a trace.
 // Example:
 //
-//	trace:span:a7880cc221e84e0d07b15993358811b7,b7880cc221e84e0d07b15993358811b7
+//	trace:span:a7880cc221e84e0d07b15993358811b7
 //
 // # Store
 //

--- a/pkg/domains/trace/doc.md
+++ b/pkg/domains/trace/doc.md
@@ -17,7 +17,7 @@ Represents a [span](<https://opentelemetry.io/docs/concepts/signals/traces/#span
 Selector has two forms:
 
 - [TraceQL](<https://grafana.com/docs/tempo/latest/traceql/>) query string
-- A list of trace IDs.
+- A hexadecimal trace\-ID.
 
 A [TraceQL](<https://grafana.com/docs/tempo/latest/traceql/>) query can select spans from many traces. Example:
 
@@ -25,10 +25,10 @@ A [TraceQL](<https://grafana.com/docs/tempo/latest/traceql/>) query can select s
 trace:span:{resource.k8s.namespace.name="korrel8r"}
 ```
 
-A trace\-id query is a list of hexadecimal trace IDs. It returns all the spans included by each trace. Example:
+A trace\-id query returns all the spans included in a trace. Example:
 
 ```
-trace:span:a7880cc221e84e0d07b15993358811b7,b7880cc221e84e0d07b15993358811b7
+trace:span:a7880cc221e84e0d07b15993358811b7
 ```
 
 ### Store

--- a/pkg/domains/trace/tempo.go
+++ b/pkg/domains/trace/tempo.go
@@ -4,7 +4,9 @@ package trace
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -12,38 +14,133 @@ import (
 	"strings"
 	"time"
 
+	"github.com/korrel8r/korrel8r/internal/pkg/logging"
 	"github.com/korrel8r/korrel8r/internal/pkg/types"
 	"github.com/korrel8r/korrel8r/pkg/korrel8r"
 	"github.com/korrel8r/korrel8r/pkg/korrel8r/impl"
 	"github.com/korrel8r/korrel8r/pkg/otel"
 )
 
-// Note: tempoTrace and tempoSpan are for decoding the tempo response, converted to Span for korrel8r.
-// Tempo uses unit-specific time and duration encodings, they converted to unambiguous time.Time, time.Duration in public Span.
+var log = logging.Log()
 
-type tempoResponse struct {
-	Traces []tempoTrace `json:"traces"`
+// searchResponse is the response from the /api/search endpoint.
+// searchTrace and searchSpan are for decoding the search response, converted to Span for korrel8r.
+// Tempo uses unit-specific time and duration encodings, they convert to unambiguous time.Time, time.Duration in public Span.
+
+type searchResponse struct {
+	Traces []searchTrace `json:"traces"`
 }
 
-type tempoTrace struct {
+type searchTrace struct {
 	TraceID         TraceID              `json:"traceID"`
 	RootServiceName string               `json:"rootServiceName,omitempty"`
 	RootTraceName   string               `json:"rootTraceName,omitempty"`
 	Start           *types.UnixNanoTime  `json:"startTimeUnixNano,omitempty"`
 	Duration        *types.MilliDuration `json:"durationMs,omitempty"`
-	SpanSets        []tempoSpanSet       `json:"spanSets,omitempty"`
-	SpanSet         *tempoSpanSet        `json:"spanSet,omitempty"` // Backwards compatibility
+	SpanSets        []searchSpanSet      `json:"spanSets,omitempty"`
+	SpanSet         *searchSpanSet       `json:"spanSet,omitempty"` // Backwards compatibility
 }
 
-type tempoSpanSet struct {
-	Spans []tempoSpan `json:"spans"`
+type searchSpanSet struct {
+	Spans []searchSpan `json:"spans"`
 }
 
-type tempoSpan struct {
+type searchSpan struct {
 	SpanID     SpanID              `json:"spanID"` // Span identifier.
 	Start      types.UnixNanoTime  `json:"startTimeUnixNano"`
 	Duration   types.MilliDuration `json:"durationNanos"`
 	Attributes otel.KeyValueList   `json:"attributes"`
+}
+
+// tracesResponse is the response from the /api/traces/{traceID} endpoint.
+// Tempo has inconsistent key names across versions:
+//   - Older Tempo: "batches"
+//   - Newer Tempo: "resourceSpans" (camelCase, OTLP JSON)
+//
+// We support both by unmarshalling into a flexible structure.
+type tracesResponse struct {
+	ResourceSpans []tracesResourceSpans `json:"-"` // Fallback, populated via custom unmarshal
+}
+
+func (r *tracesResponse) UnmarshalJSON(data []byte) error {
+	// Try "resourceSpans" (camelCase, OTLP JSON)
+	var camel struct {
+		ResourceSpans []tracesResourceSpans `json:"resourceSpans"`
+	}
+	if err := json.Unmarshal(data, &camel); err == nil && len(camel.ResourceSpans) > 0 {
+		r.ResourceSpans = camel.ResourceSpans
+		return nil
+	}
+	// Try "batches" (older Tempo)
+	var snake struct {
+		Batches []tracesResourceSpans `json:"batches"`
+	}
+	if err := json.Unmarshal(data, &snake); err == nil && len(snake.Batches) > 0 {
+		r.ResourceSpans = snake.Batches
+		return nil
+	}
+	// Try "resource_spans" (snake_case)
+	var underscore struct {
+		ResourceSpans []tracesResourceSpans `json:"resource_spans"`
+	}
+	if err := json.Unmarshal(data, &underscore); err == nil {
+		r.ResourceSpans = underscore.ResourceSpans
+		return nil
+	}
+	return nil
+}
+
+type tracesResourceSpans struct {
+	Resource   tracesResource     `json:"resource"`
+	ScopeSpans []tracesScopeSpans `json:"-"`
+}
+
+func (r *tracesResourceSpans) UnmarshalJSON(data []byte) error {
+	// Try camelCase first (Tempo actual response)
+	var camel struct {
+		Resource   tracesResource     `json:"resource"`
+		ScopeSpans []tracesScopeSpans `json:"scopeSpans"`
+	}
+	if err := json.Unmarshal(data, &camel); err == nil && len(camel.ScopeSpans) > 0 {
+		r.Resource = camel.Resource
+		r.ScopeSpans = camel.ScopeSpans
+		return nil
+	}
+	// Try snake_case (test data / older formats)
+	var snake struct {
+		Resource   tracesResource     `json:"resource"`
+		ScopeSpans []tracesScopeSpans `json:"scope_spans"`
+	}
+	if err := json.Unmarshal(data, &snake); err == nil {
+		r.Resource = snake.Resource
+		r.ScopeSpans = snake.ScopeSpans
+		return nil
+	}
+	return nil
+}
+
+type tracesResource struct {
+	Attributes otel.KeyValueList `json:"attributes"`
+}
+
+type tracesScopeSpans struct {
+	Spans []tracesSpan `json:"spans"`
+}
+
+type tracesSpan struct {
+	TraceID           []byte            `json:"trace_id"`
+	SpanID            []byte            `json:"span_id"`
+	ParentSpanID      []byte            `json:"parent_span_id"`
+	Name              string            `json:"name"`
+	StartTimeUnixNano json.Number       `json:"start_time_unix_nano"`
+	EndTimeUnixNano   json.Number       `json:"end_time_unix_nano"`
+	Attributes        otel.KeyValueList `json:"attributes"`
+	Status            tracesStatus      `json:"status"`
+}
+
+type tracesStatus struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
 }
 
 type client struct {
@@ -51,14 +148,31 @@ type client struct {
 	base *url.URL
 }
 
-func newClient(c *http.Client, base *url.URL) *client { return &client{hc: c, base: base} }
+const (
+	apiSearchPath = "/api/search"
+	apiTracesPath = "/api/traces"
+)
+
+func newClient(c *http.Client, base *url.URL) *client {
+	newBase := *base // Copy of base
+	// For backwards compatibility, strip /api/search from the end of base path.
+	newBase.Path = strings.TrimSuffix(newBase.Path, apiSearchPath)
+	return &client{
+		hc:   c,
+		base: &newBase,
+	}
+}
 
 // TODO: removed plain tempo store, not currently used. Put it back if necessary.
 // func (c *client) Get(ctx context.Context, traceQL string, collect func(*Span)) error { ... }
 
 // GetStack uses the TempoStack tenant API to get tracees for a TraceQL query with a Constraint.
-func (c *client) GetStack(ctx context.Context, traceQL string, constraint *korrel8r.Constraint, collect func(*Span)) error {
-	return c.get(ctx, traceQL, constraint, collect)
+func (c *client) GetStack(ctx context.Context, query Query, constraint *korrel8r.Constraint, collect func(*Span)) error {
+	if query.isTrace() {
+		return c.traces(ctx, query.Data(), constraint, collect)
+	} else {
+		return c.search(ctx, query.Data(), constraint, collect)
+	}
 }
 
 const ( // Tempo query keywords and field names
@@ -97,11 +211,10 @@ func defaultSelect(traceQL string) string {
 
 func formatTime(t time.Time) string { return strconv.FormatInt(t.UTC().Unix(), 10) }
 
-func (c *client) get(ctx context.Context, traceQL string, constraint *korrel8r.Constraint, collect func(*Span)) error {
-	u := *c.base // Copy, don't modify base.
-	v := url.Values{query: []string{defaultSelect(traceQL)}}
+// addConstraint adds start, end, and limit query parameters from constraint to v.
+func addConstraint(v url.Values, constraint *korrel8r.Constraint) {
 	if limit := constraint.GetLimit(); limit > 0 {
-		v.Add("limit", strconv.Itoa(limit)) // Limit is max number of traces, not spans.
+		v.Add("limit", strconv.Itoa(limit))
 	}
 	start, end := constraint.GetStart(), constraint.GetEnd()
 	if !end.IsZero() {
@@ -113,19 +226,57 @@ func (c *client) get(ctx context.Context, traceQL string, constraint *korrel8r.C
 			v.Add("end", formatTime(time.Now()))
 		}
 	}
+}
 
+func (c *client) search(ctx context.Context, traceQL string, constraint *korrel8r.Constraint, collect func(*Span)) error {
+	u := c.base.JoinPath(apiSearchPath)
+	v := url.Values{query: []string{defaultSelect(traceQL)}}
+	addConstraint(v, constraint)
 	u.RawQuery = v.Encode()
-
-	var response tempoResponse
-	if err := impl.Get(ctx, &u, c.hc, &response); err != nil {
+	var response searchResponse
+	if err := impl.Get(ctx, u, c.hc, &response); err != nil {
 		return err
 	}
-	response.collect(collect)
+	limit := constraint.GetLimit()
+	count := 0
+	response.collect(func(s *Span) {
+		if limit > 0 && count >= limit {
+			return
+		}
+		collect(s)
+		count++
+	})
+	return nil
+}
+
+// traces queries the /api/traces/{traceID} endpoint to get all spans for a single trace.
+func (c *client) traces(ctx context.Context, traceID string, constraint *korrel8r.Constraint, collect func(*Span)) error {
+	u := c.base.JoinPath(apiTracesPath, traceID)
+	v := url.Values{}
+	addConstraint(v, constraint)
+	if len(v) > 0 {
+		u.RawQuery = v.Encode()
+	}
+	log.V(5).Info("traces", "url", u.String())
+	var response tracesResponse
+	if err := impl.Get(ctx, u, c.hc, &response); err != nil {
+		return err
+	}
+	log.V(5).Info("traces", "resourceSpans", len(response.ResourceSpans))
+	limit := constraint.GetLimit()
+	count := 0
+	response.collect(func(s *Span) {
+		if limit > 0 && count >= limit {
+			return
+		}
+		collect(s)
+		count++
+	})
 	return nil
 }
 
 // collect calls collect() on each *Span.
-func (r *tempoResponse) collect(collect func(*Span)) {
+func (r *searchResponse) collect(collect func(*Span)) {
 	for _, tt := range r.Traces {
 		for _, spanSet := range tt.SpanSets {
 			tt.collect(spanSet, collect)
@@ -137,7 +288,7 @@ func (r *tempoResponse) collect(collect func(*Span)) {
 }
 
 // collect calls collect() on each *Span.
-func (tt *tempoTrace) collect(spans tempoSpanSet, collect func(*Span)) {
+func (tt *searchTrace) collect(spans searchSpanSet, collect func(*Span)) {
 	for _, ts := range spans.Spans {
 		span := &Span{
 			Name: tt.RootTraceName,
@@ -161,5 +312,64 @@ func (tt *tempoTrace) collect(spans tempoSpanSet, collect func(*Span)) {
 		// TODO: revisit, is this correct? How does tempo represent "Ok"?
 		// See otel libs for code constants.
 		collect(span)
+	}
+}
+
+// hexID converts a byte slice to a hex-encoded string, returning empty string for nil/empty input.
+func hexID(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%x", b)
+}
+
+// nanoToTime converts nanosecond Unix time (as json.Number) to time.Time.
+func nanoToTime(n json.Number) time.Time {
+	v, _ := n.Int64()
+	return time.Unix(0, v)
+}
+
+// collect calls collect() on each *Span in a tracesResponse.
+func (r *tracesResponse) collect(collect func(*Span)) {
+	log.V(5).Info("traces.collect", "resourceSpans", len(r.ResourceSpans))
+	for _, rs := range r.ResourceSpans {
+		resourceAttrs := rs.Resource.Attributes.Map()
+		log.V(5).Info("traces.collect", "scopeSpans", len(rs.ScopeSpans), "resourceAttrs", len(resourceAttrs))
+		for _, ss := range rs.ScopeSpans {
+			log.V(5).Info("traces.collect", "spans", len(ss.Spans))
+			for _, ts := range ss.Spans {
+				traceID := TraceID(hexID(ts.TraceID))
+				spanID := SpanID(hexID(ts.SpanID))
+				span := &Span{
+					Name: ts.Name,
+					Context: SpanContext{
+						TraceID: traceID,
+						SpanID:  spanID,
+					},
+					StartTime: nanoToTime(ts.StartTimeUnixNano),
+					EndTime:   nanoToTime(ts.EndTimeUnixNano),
+					Status:    Status{Code: StatusUnset},
+				}
+				if parentID := hexID(ts.ParentSpanID); parentID != "" {
+					id := SpanID(parentID)
+					span.ParentSpanID = &id
+				}
+				span.Attributes = make(map[string]any, len(resourceAttrs)+len(ts.Attributes))
+				maps.Copy(span.Attributes, resourceAttrs)
+				maps.Copy(span.Attributes, ts.Attributes.Map())
+				if ts.Status.Message != "" {
+					span.Status.Description = ts.Status.Message
+				}
+				switch ts.Status.Code {
+				case 0: // STATUS_CODE_UNSET
+					span.Status.Code = StatusUnset
+				case 1: // STATUS_CODE_OK
+					span.Status.Code = StatusOK
+				case 2: // STATUS_CODE_ERROR
+					span.Status.Code = StatusError
+				}
+				collect(span)
+			}
+		}
 	}
 }

--- a/pkg/domains/trace/tempo_test.go
+++ b/pkg/domains/trace/tempo_test.go
@@ -4,9 +4,11 @@ package trace
 
 import (
 	"encoding/json"
+	"net/url"
 	"testing"
 	"time"
 
+	"github.com/korrel8r/korrel8r/pkg/korrel8r"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -78,7 +80,7 @@ func TestUnmarshal(t *testing.T) {
       ]
 }`
 	var (
-		r     tempoResponse
+		r     searchResponse
 		spans []*Span
 	)
 	require.NoError(t, json.Unmarshal([]byte(response), &r))
@@ -118,4 +120,366 @@ func TestUnmarshal(t *testing.T) {
 			Status: Status{Code: StatusUnset}},
 	}
 	assert.Equal(t, want, spans)
+}
+
+func TestTracesResponseCollect(t *testing.T) {
+	const response = `{
+      "resource_spans": [
+        {
+          "resource": {
+            "attributes": [
+              {"key": "service.name", "value": {"stringValue": "my-service"}},
+              {"key": "service.namespace", "value": {"stringValue": "production"}}
+            ]
+          },
+          "scope_spans": [
+            {
+              "spans": [
+                {
+                  "trace_id": "Lz4M7neuXcnBet42iesuVA==",
+                  "span_id": "AQIDBAUGBwg=",
+                  "name": "GET /api/users",
+                  "start_time_unix_nano": 1684778327699392724,
+                  "end_time_unix_nano": 1684778327735077898,
+                  "attributes": [
+                    {"key": "http.method", "value": {"stringValue": "GET"}},
+                    {"key": "http.status_code", "value": {"intValue": 200}}
+                  ],
+                  "status": {"code": 1}
+                },
+                {
+                  "trace_id": "Lz4M7neuXcnBet42iesuVA==",
+                  "span_id": "qrvM3e7/ABE=",
+                  "name": "POST /api/orders",
+                  "start_time_unix_nano": 1684778327735077898,
+                  "end_time_unix_nano": 1684778327800000000,
+                  "attributes": [
+                    {"key": "http.method", "value": {"stringValue": "POST"}},
+                    {"key": "service.name", "value": {"stringValue": "override-service"}}
+                  ],
+                  "status": {"code": 2, "message": "internal error"}
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }`
+	var r tracesResponse
+	require.NoError(t, json.Unmarshal([]byte(response), &r))
+
+	var spans []*Span
+	r.collect(func(s *Span) { spans = append(spans, s) })
+	require.Len(t, spans, 2)
+
+	// First span: resource attrs merged, status OK.
+	assert.Equal(t, TraceID("2f3e0cee77ae5dc9c17ade3689eb2e54"), spans[0].Context.TraceID)
+	assert.Equal(t, SpanID("0102030405060708"), spans[0].Context.SpanID)
+	assert.Equal(t, "GET /api/users", spans[0].Name)
+	assert.Equal(t, time.Unix(0, 1684778327699392724), spans[0].StartTime)
+	assert.Equal(t, time.Unix(0, 1684778327735077898), spans[0].EndTime)
+	assert.Equal(t, Status{Code: StatusOK}, spans[0].Status)
+	assert.Equal(t, map[string]any{
+		"service.name":      "my-service",
+		"service.namespace": "production",
+		"http.method":       "GET",
+		"http.status_code":  int64(200),
+	}, spans[0].Attributes)
+
+	// Second span: span attr overrides resource attr, status Error.
+	assert.Equal(t, SpanID("aabbccddeeff0011"), spans[1].Context.SpanID)
+	assert.Equal(t, "POST /api/orders", spans[1].Name)
+	assert.Equal(t, Status{Code: StatusError, Description: "internal error"}, spans[1].Status)
+	assert.Equal(t, "override-service", spans[1].Attributes["service.name"])
+	assert.Equal(t, "POST", spans[1].Attributes["http.method"])
+	// Resource attrs still present.
+	assert.Equal(t, "production", spans[1].Attributes["service.namespace"])
+}
+
+func TestTracesResponseBatchesFormat(t *testing.T) {
+	// Test "batches" format used by older Tempo versions
+	const response = `{
+      "batches": [
+        {
+          "resource": {
+            "attributes": [
+              {"key": "service.name", "value": {"stringValue": "my-service"}}
+            ]
+          },
+          "scope_spans": [
+            {
+              "spans": [
+                {
+                  "trace_id": "Lz4M7neuXcnBet42iesuVA==",
+                  "span_id": "AQIDBAUGBwg=",
+                  "name": "GET /api/users",
+                  "start_time_unix_nano": 1684778327699392724,
+                  "end_time_unix_nano": 1684778327735077898,
+                  "status": {"code": 1}
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }`
+	var r tracesResponse
+	require.NoError(t, json.Unmarshal([]byte(response), &r))
+
+	var spans []*Span
+	r.collect(func(s *Span) { spans = append(spans, s) })
+	require.Len(t, spans, 1)
+	assert.Equal(t, TraceID("2f3e0cee77ae5dc9c17ade3689eb2e54"), spans[0].Context.TraceID)
+	assert.Equal(t, SpanID("0102030405060708"), spans[0].Context.SpanID)
+	assert.Equal(t, "GET /api/users", spans[0].Name)
+	assert.Equal(t, Status{Code: StatusOK}, spans[0].Status)
+}
+
+func TestTracesResponseCamelCaseFormat(t *testing.T) {
+	// Test "resourceSpans" with "scopeSpans" (camelCase) - actual Tempo format
+	const response = `{
+      "resourceSpans": [
+        {
+          "resource": {
+            "attributes": [
+              {"key": "service.name", "value": {"stringValue": "my-service"}}
+            ]
+          },
+          "scopeSpans": [
+            {
+              "spans": [
+                {
+                  "trace_id": "Lz4M7neuXcnBet42iesuVA==",
+                  "span_id": "AQIDBAUGBwg=",
+                  "name": "GET /api/users",
+                  "start_time_unix_nano": 1684778327699392724,
+                  "end_time_unix_nano": 1684778327735077898,
+                  "status": {"code": 1}
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }`
+	var r tracesResponse
+	require.NoError(t, json.Unmarshal([]byte(response), &r))
+
+	var spans []*Span
+	r.collect(func(s *Span) { spans = append(spans, s) })
+	require.Len(t, spans, 1)
+	assert.Equal(t, TraceID("2f3e0cee77ae5dc9c17ade3689eb2e54"), spans[0].Context.TraceID)
+	assert.Equal(t, SpanID("0102030405060708"), spans[0].Context.SpanID)
+	assert.Equal(t, "GET /api/users", spans[0].Name)
+	assert.Equal(t, Status{Code: StatusOK}, spans[0].Status)
+}
+
+func TestTracesResponseEmpty(t *testing.T) {
+	// Test empty response
+	const response = `{"resourceSpans": []}`
+	var r tracesResponse
+	require.NoError(t, json.Unmarshal([]byte(response), &r))
+
+	var spans []*Span
+	r.collect(func(s *Span) { spans = append(spans, s) })
+	assert.Empty(t, spans)
+}
+
+func TestTracesResponseNoSpans(t *testing.T) {
+	// Test response with resource but no spans
+	const response = `{
+      "resourceSpans": [
+        {
+          "resource": {
+            "attributes": [
+              {"key": "service.name", "value": {"stringValue": "my-service"}}
+            ]
+          },
+          "scopeSpans": [
+            {
+              "spans": []
+            }
+          ]
+        }
+      ]
+    }`
+	var r tracesResponse
+	require.NoError(t, json.Unmarshal([]byte(response), &r))
+
+	var spans []*Span
+	r.collect(func(s *Span) { spans = append(spans, s) })
+	assert.Empty(t, spans)
+}
+
+func TestTracesResponseParentSpanID(t *testing.T) {
+	// Test that parentSpanID is correctly parsed
+	// CgoKCgoKCgoKCg== is base64 for bytes [0x0a x10] -> hex "0a0a0a0a0a0a0a0a0a0a"
+	const response = `{
+      "resourceSpans": [
+        {
+          "resource": {
+            "attributes": []
+          },
+          "scopeSpans": [
+            {
+              "spans": [
+                {
+                  "trace_id": "Lz4M7neuXcnBet42iesuVA==",
+                  "span_id": "AQIDBAUGBwg=",
+                  "parent_span_id": "CgoKCgoKCgoKCg==",
+                  "name": "child-span",
+                  "start_time_unix_nano": 1684778327699392724,
+                  "end_time_unix_nano": 1684778327735077898,
+                  "status": {"code": 1}
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }`
+	var r tracesResponse
+	require.NoError(t, json.Unmarshal([]byte(response), &r))
+
+	var spans []*Span
+	r.collect(func(s *Span) { spans = append(spans, s) })
+	require.Len(t, spans, 1)
+	require.NotNil(t, spans[0].ParentSpanID)
+	assert.Equal(t, SpanID("0a0a0a0a0a0a0a0a0a0a"), *spans[0].ParentSpanID)
+}
+
+func TestTracesResponseMultipleResourceSpans(t *testing.T) {
+	// Test multiple resource spans
+	const response = `{
+      "resourceSpans": [
+        {
+          "resource": {
+            "attributes": [
+              {"key": "service.name", "value": {"stringValue": "service-1"}}
+            ]
+          },
+          "scopeSpans": [
+            {
+              "spans": [
+                {
+                  "trace_id": "Lz4M7neuXcnBet42iesuVA==",
+                  "span_id": "AQIDBAUGBwg=",
+                  "name": "span-1",
+                  "start_time_unix_nano": 1684778327699392724,
+                  "end_time_unix_nano": 1684778327735077898,
+                  "status": {"code": 1}
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "resource": {
+            "attributes": [
+              {"key": "service.name", "value": {"stringValue": "service-2"}}
+            ]
+          },
+          "scopeSpans": [
+            {
+              "spans": [
+                {
+                  "trace_id": "Lz4M7neuXcnBet42iesuVA==",
+                  "span_id": "qrvM3e7/ABE=",
+                  "name": "span-2",
+                  "start_time_unix_nano": 1684778327735077898,
+                  "end_time_unix_nano": 1684778327800000000,
+                  "status": {"code": 2}
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }`
+	var r tracesResponse
+	require.NoError(t, json.Unmarshal([]byte(response), &r))
+
+	var spans []*Span
+	r.collect(func(s *Span) { spans = append(spans, s) })
+	require.Len(t, spans, 2)
+	assert.Equal(t, "span-1", spans[0].Name)
+	assert.Equal(t, "service-1", spans[0].Attributes["service.name"])
+	assert.Equal(t, "span-2", spans[1].Name)
+	assert.Equal(t, "service-2", spans[1].Attributes["service.name"])
+}
+
+func TestAddConstraint(t *testing.T) {
+	tests := []struct {
+		name       string
+		constraint *korrel8r.Constraint
+		wantKeys   []string
+	}{
+		{
+			name:       "nil constraint",
+			constraint: nil,
+			wantKeys:   nil,
+		},
+		{
+			name:       "empty constraint",
+			constraint: &korrel8r.Constraint{},
+			wantKeys:   nil,
+		},
+		{
+			name: "with limit",
+			constraint: &korrel8r.Constraint{
+				Limit: intPtr(100),
+			},
+			wantKeys: []string{"limit"},
+		},
+		{
+			name: "with start and end",
+			constraint: &korrel8r.Constraint{
+				Start: timePtr(time.Unix(1000, 0)),
+				End:   timePtr(time.Unix(2000, 0)),
+			},
+			wantKeys: []string{"start", "end"},
+		},
+		{
+			name: "with start only",
+			constraint: &korrel8r.Constraint{
+				Start: timePtr(time.Unix(1000, 0)),
+			},
+			wantKeys: []string{"start", "end"},
+		},
+		{
+			name: "with all fields",
+			constraint: &korrel8r.Constraint{
+				Limit: intPtr(50),
+				Start: timePtr(time.Unix(1000, 0)),
+				End:   timePtr(time.Unix(2000, 0)),
+			},
+			wantKeys: []string{"limit", "start", "end"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := url.Values{}
+			addConstraint(v, tt.constraint)
+			for _, key := range tt.wantKeys {
+				assert.True(t, v.Has(key), "expected key %q", key)
+			}
+			assert.Equal(t, len(tt.wantKeys), len(v))
+		})
+	}
+}
+
+func intPtr(i int) *int       { return &i }
+func timePtr(t time.Time) *time.Time { return &t }
+
+func TestHexID(t *testing.T) {
+	assert.Equal(t, "", hexID(nil))
+	assert.Equal(t, "", hexID([]byte{}))
+	assert.Equal(t, "0102030405060708", hexID([]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+	assert.Equal(t, "abcdef", hexID([]byte{0xab, 0xcd, 0xef}))
+}
+
+func TestNanoToTime(t *testing.T) {
+	assert.Equal(t, time.Unix(0, 0), nanoToTime(json.Number("0")))
+	assert.Equal(t, time.Unix(0, 1684778327699392724), nanoToTime(json.Number("1684778327699392724")))
 }

--- a/pkg/domains/trace/trace.go
+++ b/pkg/domains/trace/trace.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
@@ -80,7 +81,7 @@ type Object = *Span
 // TraceID is a hex-encoded 16 byte identifier.
 type TraceID string
 
-// SpanID is a hex-encoded 16 byte identifier.
+// SpanID is a hex-encoded 8 byte identifier.
 type SpanID string
 
 // SpanContext identifies a span as part of a trace.
@@ -113,13 +114,13 @@ type Status struct {
 //
 // Span: [https://opentelemetry.io/docs/concepts/signals/traces]
 type Span struct {
-	Name       string         `json:"name"`             // Name of span.
-	Context    SpanContext    `json:"context"`          // Context identifying the span.
-	ParentID   *SpanID        `json:"spanID,omitempty"` // ParentID span ID of parent span, nil for root span.
-	StartTime  time.Time      `json:"startTime"`        // StartTime for span
-	EndTime    time.Time      `json:"endtime"`          // EndTime for span
-	Attributes map[string]any `json:"attributes"`       // Attribute map .
-	Status     Status         `json:"status"`
+	Name         string         `json:"name"`                   // Name of span.
+	Context      SpanContext    `json:"context"`                // Context identifying the span.
+	ParentSpanID *SpanID        `json:"parentSpanID,omitempty"` // ParentID span ID of parent span, nil for root span.
+	StartTime    time.Time      `json:"startTime"`              // StartTime for span
+	EndTime      time.Time      `json:"endtime"`                // EndTime for span
+	Attributes   map[string]any `json:"attributes"`             // Attribute map .
+	Status       Status         `json:"status"`
 
 	// TODO OTEL links, events not yet supported.
 }
@@ -138,6 +139,10 @@ func NewQuery(traceQL string) korrel8r.Query { return Query(strings.TrimSpace(tr
 func (q Query) Class() korrel8r.Class { return Class{} }
 func (q Query) Data() string          { return string(q) }
 func (q Query) String() string        { return korrel8r.QueryString(q) }
+
+func (q Query) isTrace() bool { return traceIDRE.MatchString(string(q)) }
+
+var traceIDRE = regexp.MustCompile("^[0-9a-f]{32}$")
 
 // NewTempoStackStore returns a store that uses a TempoStack observatorium-style URLs.
 func NewTempoStackStore(base *url.URL, h *http.Client) (korrel8r.Store, error) {
@@ -163,5 +168,5 @@ func (s *stackStore) Get(ctx context.Context, query korrel8r.Query, c *korrel8r.
 		return nil
 	}
 
-	return s.GetStack(ctx, q.Data(), c, func(s *Span) { result.Append(s) })
+	return s.GetStack(ctx, q, c, func(s *Span) { result.Append(s) })
 }

--- a/pkg/domains/trace/trace_test.go
+++ b/pkg/domains/trace/trace_test.go
@@ -9,10 +9,8 @@ import (
 	"github.com/korrel8r/korrel8r/pkg/domains/trace"
 )
 
-// TODO tempo limits number of traces, not spans. Remove ClusterSetup when fixed.
 var fixture = domain.Fixture{
-	Query:        trace.NewQuery(`{}`),
-	ClusterSetup: func(testing.TB) bool { return false },
+	Query: trace.NewQuery(`{}`),
 }
 
 func TestTraceDomain(t *testing.T)     { fixture.Test(t) }

--- a/pkg/engine/stores.go
+++ b/pkg/engine/stores.go
@@ -67,7 +67,7 @@ func (s *storeHolder) recordErrorLH(err error) {
 	if err != nil {
 		s.LastErr = err
 		s.ErrCount++
-		log.V(2).Info("Engine: Store failed", "domain", s.Domain().Name(), "error", err, "config", s.Original)
+		log.V(2).Info("Engine: Store error", "domain", s.Domain().Name(), "error", err, "config", s.Original)
 	}
 }
 
@@ -115,7 +115,7 @@ func (s *storeHolder) ensureLH() (_ korrel8r.Store, err error) {
 		return nil, fmt.Errorf("no store configuration for domain %v", s.domain.Name())
 	}
 	if time.Now().Before(s.retryAfter) {
-		return nil, s.LastErr
+		return nil, fmt.Errorf("store %v waiting to reconnect: %w", s.domain.Name(), s.LastErr)
 	}
 	defer func() {
 		if err != nil {


### PR DESCRIPTION
New Query format "trace:span:<otle-hex-trace-id>" will look up the /api/traces endpoint,
and return all spans in the trace.